### PR TITLE
Add "height" HTML property

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -225,11 +225,11 @@ class Premailer(object):
                 attributes['align'] = value.strip()
             elif key == 'background-color':
                 attributes['bgcolor'] = value.strip()
-            elif key == 'width':
+            elif key == 'width' or key == 'height':
                 value = value.strip()
                 if value.endswith('px'):
                     value = value[:-2]
-                attributes['width'] = value
+                attributes[key] = value
             #else:
             #    print "key", repr(key)
             #    print 'value', repr(value)


### PR DESCRIPTION
I noticed in some email clients, the "height" CSS property is not always respected for table cells. Adding the height as an HTML property fixes this, but Premailer was only applying width. This minor patch converts height to an HTML property as well.
