### PR TITLE
Change CSS merge order to match W3C spec

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -176,8 +176,8 @@ class Premailer(object):
             
             sel = CSSSelector(selector)
             for item in sel(page):
-                old_style = item.attrib.get('style','')
-                new_style = _merge_styles(old_style, style, class_)
+                inline_style = item.attrib.get('style','')
+                new_style = _merge_styles(style, inline_style, class_)
                 item.attrib['style'] = new_style
                 self._style_to_basic_html_attributes(item, new_style)
                 


### PR DESCRIPTION
Per the W3C CSS spec (http://www.w3.org/TR/CSS2/cascade.html#specificity), inline styles always take precedence over other style selectors. However, Premailer currently gives precedence to embedded and external selectors. When Premailer merges embedded and external styles with existing inline ones, the inline styles should take precedence.

This commit simply reverses the order of the merge to achieve this behavior.
