### PR TITLE
Optionally leave style tags intact

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,35 @@ HTML attribute `bgcolor="#eee"`.
 Having these extra attributes basically as a "back up" for really shit
 email clients that can't even take the style attributes. A lot of
 professional HTML newsletters such as Amazon's use this.
+
+
+Using with Media Queries
+------------------------
+
+For advanced designs this technique can be combined with CSS media queries. But
+style blocks with such queries must not be put inline. You can specify that
+using the `premailer="ignore"` attribute like this:
+
+    <html>
+    <head>
+        <style type="text/css">
+        /* This is put inline */
+        h1 { border:1px solid black }
+        p { color:red;}
+        p::first-letter { float:left; }
+        </style>
+        <style type="text/css" premailer="ignore">
+        /* This block is left intact and can be used to target modern mail
+         * clients that don't need inlining */
+        @media only screen and (max-device-width: 480px) {
+            /* ... */
+        }
+        </style>
+    </head>
+    <body>
+        <!-- ...... -->
+    </body>
+    </html>
+
+See the [HTML Email Boilerplate](http://htmlemailboilerplate.com/) project for
+more information about this technique.

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -160,6 +160,10 @@ class Premailer(object):
         rules = []
 
         for style in CSSSelector('style')(page):
+            if style.attrib.get('premailer', '') == 'ignore':
+                del style.attrib['premailer']
+                continue
+
             css_body = etree.tostring(style)
             css_body = css_body.split('>')[1].split('</')[0]
             these_rules, these_leftover = self._parse_style_rules(css_body)


### PR DESCRIPTION
With the new attribute `premailer` set to `ignore` a style tag is left completely intact. This is used to target modern mail clients that don't need inlining.
