### PR TITLE
Support for url_transform hook

### DIFF
--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.12-LL'
+__version__ = '1.12.1-LL'
 __build__ = ''  # set by the build server

--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,1 +1,2 @@
-from premailer import Premailer, transform, __version__
+__version__ = '1.12-LL'
+__build__ = ''  # set by the build server

--- a/premailer/api.py
+++ b/premailer/api.py
@@ -1,0 +1,10 @@
+"""
+Non-init module for doing convenient * imports from.
+"""
+
+from premailer import Premailer, transform
+
+__ignore__ = [
+    Premailer,
+    transform
+]

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -7,7 +7,7 @@ import urllib
 import urlparse
 
 
-__version__ = '1.12'
+__version__ = '1.12-LL'
 __all__ = ['PremailerError', 'Premailer', 'transform']
 
 
@@ -249,16 +249,10 @@ class Premailer(object):
                            and parent.attrib[attr].startswith('#'):
                         continue
                     if attr == 'style':
-                        attr_txt = parent.attrib[attr]
-                        pos = 0
-                        fixed = ''
-                        for m in _style_url_regex.finditer(attr_txt):
-                            url = m.group('url')
-                            url = self._process_url(url)
-                            fixed += attr_txt[pos:m.start('url')] + url
-                            pos = m.end('url')
-                        fixed += attr_txt[pos:]
-                        parent.attrib[attr] = fixed
+                        parent.attrib[attr] = _style_url_regex.sub(
+                            lambda match: "url(\'{url}\')".format(
+                                url=self._process_url(match.group('url'))),
+                            parent.attrib[attr])
                     else:
                         url = parent.attrib[attr]
                         parent.attrib[attr] = self._process_url(url)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -19,9 +19,9 @@ class PremailerError(Exception):
 def _parse_styles(style_text, specificity):
     """Parse a style string into a dictionary {style_key: (style_value, specificity)}."""
 
-    return {k.strip(): (v.strip(), specificity)
-            for k, v in [x.strip().split(':', 1)
-                         for x in style_text.split(';') if x.strip()]}
+    return dict([(k.strip(), (v.strip(), specificity))
+                 for k, v in [x.strip().split(':', 1)
+                              for x in style_text.split(';') if x.strip()]])
 
 
 def _inline_specificity():
@@ -324,9 +324,6 @@ def _style_to_basic_html_attributes(element, style_content, force=False):
             if value.endswith('px'):
                 value = value[:-2]
             attributes[key] = value
-        #else:
-        #    print "key", repr(key)
-        #    print 'value', repr(value)
 
     for key, value in attributes.items():
         if key in element.attrib and not force:

--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -464,9 +464,8 @@ def test_css_with_pseudoclasses_included():
     assert 'style="{color:red; border:1px solid green}' in result_html
     assert ' :visited{border:1px solid green}' in result_html
     assert ' :hover{border:1px solid green; text-decoration:none}' in \
-      result_html
+        result_html
     print result_html
-    # assert 0
 
 
 def test_css_with_pseudoclasses_excluded():

--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -2,39 +2,69 @@ import re
 import urlparse
 from nose.tools import eq_, ok_
 
-from premailer import Premailer, etree, _merge_styles
+from premailer import Premailer, etree
 
 
 def test_merge_styles_basic():
-    old = 'font-size:1px; color: red'
-    new = 'font-size:2px; font-weight: bold'
-    expect = 'color:red;', 'font-size:2px;', 'font-weight:bold'
-    result = _merge_styles(old, new)
-    for each in expect:
-        assert each in result
+    html = """<html>
+    <head>
+    <style type="text/css">
+    p { font-size:2px; font-weight: bold }
+    </style>
+    </head>
+    <body>
+    <p style="font-size:1px; color: red">hello</p>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <p style="color:red; font-size:1px; font-weight:bold">hello</p>
+    </body>
+    </html>"""
+
+    p = Premailer(html)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    assert expect_html == result_html
 
 
 def test_merge_styles_with_class():
-    old = 'color:red; font-size:1px;'
-    new, class_ = 'font-size:2px; font-weight: bold', ':hover'
+    html = """<html>
+    <head>
+    <style type="text/css">
+    p:hover{font-size:2px; font-weight:bold}
+    </style>
+    </head>
+    <body>
+    <p style="font-size:1px; color: red">hello</p>
+    </body>
+    </html>"""
 
-    # because we're dealing with dicts (random order) we have to
-    # test carefully.
-    # We expect something like this:
-    #  {color:red; font-size:1px} :hover{font-size:2px; font-weight:bold}
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <p style="{color:red; font-size:1px} :hover{font-size:2px; font-weight:bold}">hello</p>
+    </body>
+    </html>"""
 
-    result = _merge_styles(old, new, class_)
-    ok_(result.startswith('{'))
-    ok_(result.endswith('}'))
-    ok_(' :hover{' in result)
-    split_regex = re.compile('{([^}]+)}')
-    eq_(len(split_regex.findall(result)), 2)
-    expect_first = 'color:red', 'font-size:1px'
-    expect_second = 'font-weight:bold', 'font-size:2px'
-    for each in expect_first:
-        ok_(each in split_regex.findall(result)[0])
-    for each in expect_second:
-        ok_(each in split_regex.findall(result)[1])
+    p = Premailer(html)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    assert expect_html == result_html
 
 
 def test_basic_html():
@@ -560,6 +590,7 @@ def test_apple_newsletter_example():
         '* {line-height: normal !important; -webkit-text-size-adjust: 125%}\n'
         '</style>' in result_html)
 
+
 def test_mailto_url():
     """if you use URL with mailto: protocol, they should stay as mailto:
     when baseurl is used
@@ -816,6 +847,7 @@ def test_child_selector():
 
     eq_(expect_html, result_html)
 
+
 def test_doctype():
     html = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html>
@@ -830,6 +862,135 @@ def test_doctype():
     <head>
     </head>
     <body>
+    </body>
+    </html>"""
+
+    p = Premailer(html)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)
+
+
+def test_css_specificity():
+    html = """<html>
+    <head>
+    <style type="text/css">
+    td.content-inner p {padding-bottom:10px;}
+    p {padding-bottom:0;}
+    </style>
+    </head>
+    <body>
+    <p>text</p>
+    <table>
+    <tr>
+    <td class="content-inner">
+    <p>some text</p>
+    </td>
+    </tr>
+    </table>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <p style="padding-bottom:0">text</p>
+    <table>
+    <tr>
+    <td>
+    <p style="padding-bottom:10px">some text</p>
+    </td>
+    </tr>
+    </table>
+    </body>
+    </html>"""
+
+    p = Premailer(html)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)
+
+
+def test_css_selector_grouping():
+    html = """<html>
+    <head>
+    <style type="text/css">
+    h1,h2,h3 {color: black}
+    h1 {font-size: 24px; color: red}
+    h1.major {font-size: 48px}
+    h1#title {font-weight: bold}
+    h2#subtitle {font-size: 12px}
+    </style>
+    </head>
+    <body>
+    <h1 id="title" class="major">h1 title text</h1>
+    <h1>h1 text</h1>
+    <h2 id="subtitle">h2 text</h2>
+    <h3>h3 text</h3>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <h1 id="title" style="color:red; font-size:48px; font-weight:bold">h1 title text</h1>
+    <h1 style="color:red; font-size:24px">h1 text</h1>
+    <h2 id="subtitle" style="color:black; font-size:12px">h2 text</h2>
+    <h3 style="color:black">h3 text</h3>
+    </body>
+    </html>"""
+
+    p = Premailer(html)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)
+
+
+def test_general():
+    html = """<html>
+        <head>
+        <title>Test</title>
+        <style>
+        h1, h2 { color:red; }
+        strong {
+          text-decoration:none
+          }
+        p { font-size:2px }
+        p.footer { font-size: 1px}
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        <p class="footer" style="color:red">Feetnuts</p>
+        </body>
+        </html>"""
+
+    expect_html = """<html>
+    <head>
+    <title>Test</title>
+    </head>
+    <body>
+    <h1 style="color:red">Hi!</h1>
+    <p style="font-size:2px"><strong style="text-decoration:none">Yes!</strong></p>
+    <p style="color:red; font-size:1px">Feetnuts</p>
     </body>
     </html>"""
 

--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -262,16 +262,16 @@ def test_base_url_for_style_block_urls():
     </body>
     </html>"""
 
-    expect_html = '''<html>
+    expect_html = """<html>
     <head>
     <title>Title</title>
     </head>
-    <body style="color:#123; fun:url(\'http://example.com/images/fun.png\'); ''' \
-     'font-family:Omerta; background:url(http://example.com/images/bg.png); ' \
-     'extra-fun:url(  &quot;http://example.com/images/extra_fun.png&quot; )">' \
-    '''<h1>Hi!</h1>
+    <body style="color:#123; fun:url('http://example.com/images/fun.png'); """ \
+     "font-family:Omerta; background:url('http://example.com/images/bg.png'); " \
+     "extra-fun:url('http://example.com/images/extra_fun.png')\">" \
+    """<h1>Hi!</h1>
     </body>
-    </html>'''
+    </html>"""
 
     p = Premailer(html, base_url='http://example.com')
     result_html = p.transform()
@@ -309,18 +309,18 @@ def test_url_transform():
     </body>
     </html>"""
 
-    expect_html = '''<html>
+    expect_html = """<html>
     <head>
     <title>Title</title>
     </head>
-    <body style="color:#123; font-family:Omerta; background:url(http://example.com/static/images/bg.png)">
+    <body style="color:#123; font-family:Omerta; background:url('http://example.com/static/images/bg.png')">
     <h1>Hi!</h1>
     <img src="http://example.com/static/images/foo.jpg">
     <img src="http://www.googe.com/photos/foo.jpg">
     <a href="http://example.com/home">Home</a>
     <a href="http://www.peterbe.com">External</a>
     </body>
-    </html>'''
+    </html>"""
 
     def url_transform(url):
         """Add 'static/' before 'example.com' image urls."""
@@ -342,9 +342,6 @@ def test_url_transform():
 
     expect_html = whitespace_between_tags.sub('><', expect_html).strip()
     result_html = whitespace_between_tags.sub('><', result_html).strip()
-    print expect_html
-    print
-    print result_html
     assert expect_html == result_html
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.11'
+version = '1.12'
 
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 long_description = open(README).read().strip() + "\n\n"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 from setuptools import setup, find_packages
-
-version = '1.12-LL'
+from premailer import __version__, __build__
 
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 long_description = open(README).read().strip() + "\n\n"
@@ -16,7 +15,7 @@ long_description = md2stx(long_description)
 
 
 setup(name='premailer',
-      version=version + os.environ.get('BUILD_SUFFIX', ''),
+      version=__version__ + __build__,
       description="Turns CSS blocks into style attributes",
       long_description=long_description,
       keywords='html lxml email mail style',
@@ -26,17 +25,17 @@ setup(name='premailer',
       download_url='http://github.com/peterbe/premailer',
       license='Python',
       classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Other Environment",
-        "Environment :: Web Environment",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Python Software Foundation License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Topic :: Communications",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Other/Nonlisted Topic",
-        "Topic :: Software Development :: Libraries :: Python Modules",
+          "Development Status :: 5 - Production/Stable",
+          "Environment :: Other Environment",
+          "Environment :: Web Environment",
+          "Intended Audience :: Developers",
+          "License :: OSI Approved :: Python Software Foundation License",
+          "Operating System :: OS Independent",
+          "Programming Language :: Python",
+          "Topic :: Communications",
+          "Topic :: Internet :: WWW/HTTP",
+          "Topic :: Other/Nonlisted Topic",
+          "Topic :: Software Development :: Libraries :: Python Modules",
       ],
       packages=find_packages(),
       include_package_data=True,
@@ -44,8 +43,8 @@ setup(name='premailer',
       tests_require=['Nose'],
       zip_safe=True,
       install_requires=[
-        'lxml',
-        'cssselect'
+          'lxml==3.0.2',
+          'cssselect==0.7.1'
       ],
       entry_points="""
       # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.12'
+version = '1.12-LL'
 
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 long_description = open(README).read().strip() + "\n\n"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = md2stx(long_description)
 
 
 setup(name='premailer',
-      version=version,
+      version=version + os.environ.get('BUILD_SUFFIX', ''),
       description="Turns CSS blocks into style attributes",
       long_description=long_description,
       keywords='html lxml email mail style',
@@ -45,6 +45,7 @@ setup(name='premailer',
       zip_safe=True,
       install_requires=[
         'lxml',
+        'cssselect'
       ],
       entry_points="""
       # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ setup(name='premailer',
       packages=find_packages(),
       include_package_data=True,
       test_suite='nose.collector',
-      tests_require=['Nose'],
+      tests_require=['nose'],
       zip_safe=True,
       install_requires=[
-          'lxml==3.0.2',
-          'cssselect==0.7.1'
+          'lxml',
+          'cssselect'
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
The main purpose of forking this project was to add a new url_transform hook to apply changes to urls. 
For example, to return a hashed url for versioning that we at Location Labs use for our static content. 
I also added support for base_url fix for urls inside style blocks that was missing, and also added missing install_requires dependency on cssselect.
Finally, I added the appropriate tests to verify my changes.
