### PR TITLE
add trusted pseudo-classes argument

### DIFF
--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -1441,3 +1441,83 @@ def test_external_styles_and_links():
     result_html = whitespace_between_tags.sub('><', result_html).strip()
 
     eq_(expect_html, result_html)
+
+
+def test_trusted_pseudo():
+    html = """<html>
+    <head>
+    <style type="text/css">
+    div {
+        color: red;
+    }
+    div:not(:nth-child(1)) {
+        color: blue;
+    }
+    p:hover {
+        color: green;
+    }
+    </style>
+    </head>
+    <body>
+    <div>First child</div>
+    <p>Middle child</p>
+    <div>Last child</div>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <div style="color:red">First child</div>
+    <p>Middle child</p>
+    <div style="color:blue">Last child</div>
+    </body>
+    </html>"""
+
+    p = Premailer(html, trust_pseudoclasses=True)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)
+
+def test_trusted_pseudo_bad_selector():
+    html = """<html>
+    <head>
+    <style type="text/css">
+    div {
+        color: red;
+    }
+    div:not(:not(:first-child)) {
+        color: blue
+    }
+    </style>
+    </head>
+    <body>
+    <div>First child</div>
+    <div>Last child</div>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    </head>
+    <body>
+    <div style="color:red">First child</div>
+    <div style="color:red">Last child</div>
+    </body>
+    </html>"""
+
+    p = Premailer(html, trust_pseudoclasses=True)
+    result_html = p.transform()
+
+    whitespace_between_tags = re.compile('>\s*<',)
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)


### PR DESCRIPTION
It useful to wide cssselect pseudo-classes support like `:not()`, `:nth-child()`, `:nth-last-child`, `:nth-of-type()`, `:nth-last-of-type()` and etc.  For this case pseudo-classes as `:hover`, `:active` and etc. will processed but not left in style attribute, so you must use for this `keep_style_tags` argument.
