### PR TITLE
Improve external library loading error message

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -316,7 +316,8 @@ class Premailer(object):
         else:
             stylefile = url
             if not os.path.isabs(stylefile):
-                stylefile = os.path.join(self.base_path or '', stylefile)
+                stylefile = os.path.abspath(os.path.join(self.base_path or '',
+                                                         stylefile))
             if os.path.exists(stylefile):
                 with codecs.open(stylefile, encoding='utf-8') as f:
                     css_body = f.read()


### PR DESCRIPTION
Easier to debug a dodgy base_path if the error message says (eg.) "Could not
find external style: /home/lamby/media.css" vs. "Could not find external style:
"media.css".
