### PR TITLE
Adding option to disable CSSParser validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can also use premailer from the command line by using his main module.
       --remove-classes      Remove all class attributes from all elements
       --strip-important     Remove '!important' for all css declarations.
       --disable-basic-attributes Disable provided basic attributes (comma separated)
+      --disable-validation  Disable CSSParser validation of attributes and values
 
 A basic example:
 

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -85,6 +85,12 @@ def main(args):
         help="Disable provided basic attributes (comma separated)", default=[]
     )
 
+    parser.add_argument(
+        "--disable-validation", default=False,
+        action="store_true", dest="disable_validation",
+        help="Disable CSSParser validation of attributes and values",
+    )
+
     options = parser.parse_args(args)
 
     if options.disable_basic_attributes:
@@ -102,7 +108,8 @@ def main(args):
         external_styles=options.external_styles,
         method=options.method,
         base_path=options.base_path,
-        disable_basic_attributes=options.disable_basic_attributes
+        disable_basic_attributes=options.disable_basic_attributes,
+        disable_validation=options.disable_validation
     )
     options.outfile.write(p.transform())
     return 0

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -124,7 +124,8 @@ class Premailer(object):
                  external_styles=None,
                  method="html",
                  base_path=None,
-                 disable_basic_attributes=None):
+                 disable_basic_attributes=None,
+                 disable_validation=False):
         self.html = html
         self.base_url = base_url
         self.preserve_internal_links = preserve_internal_links
@@ -144,6 +145,7 @@ class Premailer(object):
         if disable_basic_attributes is None:
             disable_basic_attributes = []
         self.disable_basic_attributes = disable_basic_attributes
+        self.disable_validation = disable_validation
 
     def _parse_style_rules(self, css_body, ruleset_index):
         leftover = []
@@ -152,7 +154,7 @@ class Premailer(object):
         # empty string
         if not css_body:
             return rules, leftover
-        sheet = cssutils.parseString(css_body)
+        sheet = cssutils.parseString(css_body, validate=not self.disable_validation)
         for rule in sheet:
             # ignore comment
             if rule.type == rule.COMMENT:

--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -1664,3 +1664,44 @@ def test_external_styles_with_base_url(urllib2):
     result_html = whitespace_between_tags.sub('><', result_html).strip()
 
     eq_(expect_html, result_html)
+
+def test_disabled_validator():
+    """test disabled_validator"""
+    if not etree:
+        # can't test it
+        return
+
+    html = """<html>
+    <head>
+    <title>Title</title>
+    <style type="text/css">
+    h1, h2 { fo:bar; }
+    strong {
+        color:baz;
+        text-decoration:none;
+        }
+    </style>
+    </head>
+    <body>
+    <h1>Hi!</h1>
+    <p><strong>Yes!</strong></p>
+    </body>
+    </html>"""
+
+    expect_html = """<html>
+    <head>
+    <title>Title</title>
+    </head>
+    <body>
+    <h1 style="fo:bar">Hi!</h1>
+    <p><strong style="color:baz; text-decoration:none">Yes!</strong></p>
+    </body>
+    </html>"""
+
+    p = Premailer(html, disable_validation=True)
+    result_html = p.transform()
+
+    expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+    result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+    eq_(expect_html, result_html)


### PR DESCRIPTION
Allowing the user to disable the CSSParser validator that [`cssutils.parseString`](http://pythonhosted.org/cssutils/docs/parse.html#parsestring) uses. This adds an optional argument that allows the parser to inline unsupported attributes and values.

``` css
.example-1 {
  fo: bar;
}
.example-2 {
  color: baz;
}
```
