### PR TITLE
Keep original css 'fixes' #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ You can also use premailer from the command line by using his main module.
       --preserve-style-tags
                             Do not delete <style></style> tags from the html
                             document.
+      --keep-original-css
+                            Never remove or strip any of the original css found in
+                            the original head of the document. This will produce duplicate
+                            declarations.
       --remove-star-selectors
                             All wildcard selectors like '* {color: black}' will be
                             removed.

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -51,6 +51,12 @@ def main(args):
     )
 
     parser.add_argument(
+        "--keep-original-css", default=False,
+        help="Never remove or strip any of the original css found in the original head of the document.",
+        action="store_true", dest="keep_original_css"
+    )
+
+    parser.add_argument(
         "--remove-star-selectors", default=True,
         help="All wildcard selectors like '* {color: black}' will be removed.",
         action="store_false", dest="include_star_selectors"
@@ -104,6 +110,7 @@ def main(args):
         preserve_internal_links=options.preserve_internal_links,
         exclude_pseudoclasses=options.exclude_pseudoclasses,
         keep_style_tags=options.keep_style_tags,
+        keep_original_css=options.keep_original_css,
         include_star_selectors=options.include_star_selectors,
         remove_classes=options.remove_classes,
         strip_important=options.strip_important,

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -139,8 +139,7 @@ class Premailer(object):
         # whether to delete the <style> tag once it's been processed
         self.keep_style_tags = keep_style_tags
         self.remove_classes = remove_classes
-        # always keep the original css in order to preserve non found
-        # classes like '.yshortcuts a {border-bottom: none !important;}'
+        # always keep the original css in its original form found in head styles
         self.keep_original_css = keep_original_css
         # whether to process or ignore selectors like '* { foo:bar; }'
         self.include_star_selectors = include_star_selectors

--- a/premailer/test-issue50.html
+++ b/premailer/test-issue50.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<style type="text/css">
+.yshortcuts a {border-bottom: none !important;}
+@media screen and (max-width: 600px) {
+    table[class="container"] {
+        width: 100% !important;
+    }
+}
+/* Also comments should be preserved when the --keep-original-css flag is set */
+p {font-size:12px;}
+</style>
+</head>
+<body>
+<p>html</p>
+</body>
+</html>

--- a/premailer/test_premailer.py
+++ b/premailer/test_premailer.py
@@ -1445,6 +1445,51 @@ class Tests(unittest.TestCase):
 
         compare_html(expect_html, result_html)
 
+    def test_command_line_keep_original_css(self):
+        with captured_output() as (out, err):
+            main([
+                '-f',
+                'premailer/test-issue50.html',
+                '--keep-original-css'
+            ])
+
+        result_html = out.getvalue().strip()
+
+        expect_html = """
+        <html>
+        <head>
+        <style type="text/css">
+        .yshortcuts a {border-bottom: none !important;}
+        @media screen and (max-width: 600px) {
+            table[class="container"] {
+                width: 100% !important;
+            }
+        }
+        /* Also comments should be preserved when the --keep-original-css flag is set */
+        p {font-size:12px;}
+        </style>
+        </head>
+        <body>
+        <p style="font-size:12px">html</p>
+        </body>
+        </html>
+        """
+        # print result_html
+        compare_html(expect_html, result_html)
+
+        # also test together with --preserve-style-tags
+        with captured_output() as (out, err):
+            main([
+                '-f',
+                'premailer/test-issue50.html',
+                '--preserve-style-tags',
+                '--keep-original-css'
+            ])
+        print result_html
+        result_html = out.getvalue().strip()
+
+        compare_html(expect_html, result_html)
+
     def test_multithreading(self):
         """The test tests thread safety of merge_styles function which employs
         thread non-safe cssutils calls.


### PR DESCRIPTION
Ok, so i'm not sure if you want to merge this and add support for the `--keep-original-css` flag.

I do think it's useful to be able to always keep the css exactly as it was.

If that was the intention of the `--preserve-style-tags` then that's a bug as it doesn't work for the test file `test-issue50.html`

Basically when there are media queries included it breaks.

So, this really doesn't fix the bug and if the intention of --preserve-style-tags is to always keep all of the css (including comments for example) then I would suggest doing as `--keep-original-css` is doing it here.

Let me know what you want to do. 
