### PR TITLE
Add css_text option to allow css strings to be provided

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -83,6 +83,12 @@ def main(args):
         "--external-style", action="append", dest="external_styles",
         help="The path to an external stylesheet to be loaded."
     )
+
+    parser.add_argument(
+        "--css-text", action="append", dest="css_text",
+        help="CSS text to be applied to the html."
+    )
+
     parser.add_argument(
         "--disable-basic-attributes", dest="disable_basic_attributes",
         help="Disable provided basic attributes (comma separated)", default=[]
@@ -113,6 +119,7 @@ def main(args):
         remove_classes=options.remove_classes,
         strip_important=options.strip_important,
         external_styles=options.external_styles,
+        css_text=options.css_text,
         method=options.method,
         base_path=options.base_path,
         disable_basic_attributes=options.disable_basic_attributes,

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -1713,6 +1713,109 @@ class Tests(unittest.TestCase):
         mocked_url_open.assert_called_once_with(faux_uri)
         self.assertEqual(faux_response.decode('utf-8'), r)
 
+    def test_css_text(self):
+        """Test handling css_text passed as a string"""
+
+        html = """<html>
+        <head>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">@media all and (max-width: 320px) {
+            h1 {
+                color: black !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>"""
+
+        css_text = """
+        h1 {
+            color: brown;
+        }
+        h2 {
+            color: green;
+        }
+        a {
+            color: pink;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                color: black;
+            }
+        }
+
+        """
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            css_text=[css_text])
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_css_text_with_only_body_present(self):
+        """Test handling css_text passed as a string when no <html> or <head> is present"""
+
+        html = """<body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">@media all and (max-width: 320px) {
+            h1 {
+                color: black !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>"""
+
+        css_text = """
+        h1 {
+            color: brown;
+        }
+        h2 {
+            color: green;
+        }
+        a {
+            color: pink;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                color: black;
+            }
+        }
+        """
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            css_text=css_text)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
     @staticmethod
     def mocked_urlopen(url):
         'The standard "response" from the "server".'


### PR DESCRIPTION
This adds a new option to Premailer - `css_text` - which allows you to pass some css in directly that should be applied to the given html.

This is very useful if you are sending thousands of emails, each one with personalised content, but that all use the same CSS file. The css file(s) can then be read once and cached and passed directly to Premailer each time, avoiding any additional disc/network IO.

**Before**

``` python
for recipient in recipients:
    html = render_html(recipient)
    # will read from disc every time
    html = Premailer(html, external_style='style.css').transform()
    send_email(html)
```

**After**

``` python
# read from disc once
css = read_file('style.css')
for recipient in recipients:
    html = render_html(recipient)
    # no disc IO needed
    html = Premailer(html, css_text=css).transform()
    send_email(html)
```

Additionally fixed some pep8/flake8 warnings.
