### PR TITLE
Remove exclude_pseudoclasses option and improve performance

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -40,12 +40,6 @@ def main(args):
     )
 
     parser.add_argument(
-        "--exclude-pseudoclasses", default=False,
-        help="Pseudo classes like p:last-child', p:first-child, etc",
-        action="store_true", dest="exclude_pseudoclasses"
-    )
-
-    parser.add_argument(
         "--preserve-style-tags", default=False,
         help="Do not delete <style></style> tags from the html document.",
         action="store_true", dest="keep_style_tags"
@@ -113,7 +107,6 @@ def main(args):
         html=html,
         base_url=options.base_url,
         preserve_internal_links=options.preserve_internal_links,
-        exclude_pseudoclasses=options.exclude_pseudoclasses,
         keep_style_tags=options.keep_style_tags,
         include_star_selectors=options.include_star_selectors,
         remove_classes=options.remove_classes,


### PR DESCRIPTION
We have been using premailer for a while for a new internal email system sending fairly large volumes of emails and have encountered some severe performance issues, sometimes inlining css would take almost a second, which meant it was impossible to send the volume of emails needed within the time frames needed. So we started digging into where the performance issues were coming from and it turned out to be in `merge_styles`. We are now using a forked version of premailer with this change and we are seeing big performance improvements.

Delving a little deeper it appears that the option `exclude_pseudoclasses` is not really needed as as far as I can see it is not possible to inline pseudo selectors such as `:hover` or `::first-letter`. For an example see [this JSFiddle](http://jsfiddle.net/shvL1dj5/). This makes it much easier to implement `merge_styles` without using `cssutils`, which requires threading locks.

I'm aware that this is a breaking change but I think given the performance improvements, and the fact that the current behaviour actually produces invalid CSS, it is worth it.

Some timing using `timeit`:

``` sh
# current master
>>> timeit.timeit("premailer.premailer.transform('<html><head><style>a { color: red; }p { color: blue; font-size: 20px; } .class {font-weight: bold;}</style></head><body><a></a><p></p><div class=\"class\"></div></body></html>')", setup='import premailer', number=10000)
45.349464893341064

# this branch
>>> timeit.timeit("premailer.premailer.transform('<html><head><style>a { color: red; }p { color: blue; font-size: 20px; } .class {font-weight: bold;}</style></head><body><a></a><p></p><div class=\"class\"></div></body></html>')", setup='import premailer', number=10000)
29.674472093582153

```
