### PR TITLE
Performance improvement of inline styling

### DIFF
--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -19,7 +19,22 @@ class _Cache(object):
         self.cache = {}
 
 def function_cache(expected_max_entries=1000):
-    
+    """
+        function_cache is a decorator for caching function call
+        the argument to the wrapped function must be hashable else
+        it will not work
+        
+        expected_max_entries is for protecting cache failure. If cache misses more than
+        this number the cache will turn off itself. Specify None you sure that the cache
+        will not cause memory limit problem
+        
+        Args:
+            expected_max_entries(integer OR None): will raise if not correct
+            
+        Returns:
+            function
+            
+    """
     if expected_max_entries is not None and not isinstance(expected_max_entries, int):
         raise TypeError('Expected expected_max_entries to be an integer or None')
     

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -1,0 +1,58 @@
+import functools
+
+class _HashedSeq(list):
+    # # From CPython
+    __slots__ = 'hashvalue'
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+## if we only have nonlocal
+class _Cache(object):
+    def __init__(self):
+        self.off = False
+        self.missed = 0
+        self.cache = {}
+
+def function_cache(expected_max_entries=1000):
+    
+    if expected_max_entries is not None and not isinstance(expected_max_entries, int):
+        raise TypeError('Expected expected_max_entries to be an integer or None')
+    
+    # indicator of cache missed
+    sentinel = object() 
+    
+    def decorator(func):
+        cached = _Cache()
+    
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            if cached.off:
+                return func(*args, **kwargs)
+            
+            keys = args
+            if kwargs:
+                sorted_items = sorted(kwargs.items())   
+                for item in sorted_items:
+                    keys += item
+                    
+            hashed = hash(_HashedSeq(keys))
+            result = cached.cache.get(hashed, sentinel)
+            if result is sentinel:
+                cached.missed += 1
+                result = func(*args, **kwargs)
+                cached.cache[hashed] = result
+                # # something is wrong if we are here more than expected
+                # # empty and turn it off
+                if expected_max_entries is not None and cached.missed > expected_max_entries:
+                    cached.off = True
+                    cached.cache.clear()
+                    
+            return result
+            
+        return inner
+    return decorator

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -32,9 +32,10 @@ def merge_styles(inline_style, new_styles, classes):
             str: the final style
     """
     # building classes
-    styles = {pc: {} for pc in set(classes)}
-    # probably faster just override
-    styles[''] = {}
+    styles = {'': {}}
+    for pc in set(classes):
+        styles[pc] = {}
+    
     for i, style in enumerate(new_styles):
         for k, v in style:
             styles[classes[i]][k] = v

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -1,0 +1,70 @@
+
+import cssutils
+import threading
+import re
+
+
+def csstext_to_pairs(csstext):
+    """
+        csstext_to_pairs takes css text and make it to list of tuple of key,value
+    """
+    # The lock is required to avoid ``cssutils`` concurrency issues documented in issue #65
+    with csstext_to_pairs._lock:
+        parsed = cssutils.css.CSSVariablesDeclaration(csstext)
+        return [(key.strip(), parsed.getVariableValue(key).strip()) for key in sorted(parsed)]
+
+csstext_to_pairs._lock = threading.RLock()
+
+grouping_regex = re.compile('([:\-\w]*){([^}]+)}')
+
+def merge_styles(inline_style, new_styles, classes):    
+    """
+        This will merge all new styles where the order is important
+        The last one will override the first
+        When that is done it will apply old inline style again
+        
+        Args:
+            inline_style(str): the old inline style of the element if there is one
+            new_styles: a list of new styles, each element should be a list of tuple
+            classes: a list of classes which maps new_styles, important! 
+            
+        Returns:
+            str: the final style
+    """
+    # building classes
+    styles = {pc: {} for pc in set(classes)}
+    # probably faster just override
+    styles[''] = {}
+    for i, style in enumerate(new_styles):
+        for k, v in style:
+            styles[classes[i]][k] = v
+            
+    # keep always the old inline style
+    if inline_style:
+        ## finding pseudoclasses
+        grouped_split = grouping_regex.findall(inline_style)
+        if grouped_split:
+            for old_class, old_content in grouped_split:
+                for k, v in csstext_to_pairs(old_content):
+                    styles[old_class][k] = v
+        else:
+            for k, v in csstext_to_pairs(inline_style):
+                styles[''][k] = v
+        
+    normal_styles = []
+    pseudo_styles = []
+    for pseudoclass, kv in styles.items():
+        if not kv:
+            continue
+        if pseudoclass:
+            pseudo_styles.append('%s{%s}' % (pseudoclass ,'; '.join('%s:%s' % (k, v) for k, v in sorted(kv.items()))))
+        else:
+            normal_styles.append('; '.join('%s:%s' % (k, v) for k, v in sorted(kv.items())))
+    
+    if pseudo_styles:
+        all_styles = (['{%s}' % ''.join(normal_styles)] + pseudo_styles) if normal_styles else pseudo_styles
+    else:
+        all_styles = normal_styles
+        
+    return ' '.join(all_styles).strip()
+

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -15,8 +15,6 @@ def csstext_to_pairs(csstext):
 
 csstext_to_pairs._lock = threading.RLock()
 
-grouping_regex = re.compile('([:\-\w]*){([^}]+)}')
-
 def merge_styles(inline_style, new_styles, classes):    
     """
         This will merge all new styles where the order is important
@@ -41,15 +39,10 @@ def merge_styles(inline_style, new_styles, classes):
             
     # keep always the old inline style
     if inline_style:
-        ## finding pseudoclasses
-        grouped_split = grouping_regex.findall(inline_style)
-        if grouped_split:
-            for old_class, old_content in grouped_split:
-                for k, v in csstext_to_pairs(old_content):
-                    styles[old_class][k] = v
-        else:
-            for k, v in csstext_to_pairs(inline_style):
-                styles[''][k] = v
+        # inline should be a declaration list as I understand
+        # ie property-name:property-value;...
+        for k, v in csstext_to_pairs(inline_style):
+            styles[''][k] = v
         
     normal_styles = []
     pseudo_styles = []

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -20,6 +20,8 @@ def merge_styles(inline_style, new_styles, classes):
         This will merge all new styles where the order is important
         The last one will override the first
         When that is done it will apply old inline style again
+        The old inline style is always important and override
+        all new ones. The inline style must be valid.
         
         Args:
             inline_style(str): the old inline style of the element if there is one
@@ -55,9 +57,11 @@ def merge_styles(inline_style, new_styles, classes):
             normal_styles.append('; '.join('%s:%s' % (k, v) for k, v in sorted(kv.items())))
     
     if pseudo_styles:
+        # if we do or code thing correct this should not happen
+        # inline style definition: declarations without braces
         all_styles = (['{%s}' % ''.join(normal_styles)] + pseudo_styles) if normal_styles else pseudo_styles
     else:
         all_styles = normal_styles
-        
+    
     return ' '.join(all_styles).strip()
 

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -347,8 +347,6 @@ class Premailer(object):
             if len(items):
                 # same so process it first
                 processed_style = csstext_to_pairs(style)
-                if not processed_style:
-                    continue
 
                 for item in items:
                     item_id = id(item)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -70,6 +70,9 @@ def _cache_parse_css_string(css_body, validate=True):
     """
         This function will cache the result from cssutils
         It is a big gain when number of rules is big
+        Maximum cache entries are 1000. This is mainly for
+        protecting memory leak in case something gone wild.
+        Be aware that you can turn the cache off in Premailer 
 
         Args:
             css_body(str): css rules in string format
@@ -371,9 +374,9 @@ class Premailer(object):
                 parent = item.getparent()
                 del parent.attrib['class']
 
-        # #
-        # # URLs
-        # #
+        ##
+        ## URLs
+        ##
         if self.base_url:
             for attr in ('href', 'src'):
                 for item in page.xpath("//@%s" % attr):

--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 
 from premailer.cache import function_cache
-
+from nose.tools import raises
 
 class TestCache(unittest.TestCase):
 
+    @raises(TypeError)
     def test_expected_max_entries_raise(self):
-        with self.assertRaises(TypeError):
-            function_cache(expected_max_entries='testing')
+        function_cache(expected_max_entries='testing')
         
     def test_auto_turn_off(self):
         test = {'call_count':0}

--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, unicode_literals
+import unittest
+
+from premailer.cache import function_cache
+
+
+class TestCache(unittest.TestCase):
+
+    def test_expected_max_entries_raise(self):
+        with self.assertRaises(TypeError):
+            function_cache(expected_max_entries='testing')
+        
+    def test_auto_turn_off(self):
+        test = {'call_count':0}
+        def test_func(*args, **kwargs):
+            test['call_count'] += 1
+            
+        cache_decorator = function_cache(expected_max_entries=2)
+        wrapper = cache_decorator(test_func)
+        wrapper(1, 1, t=1)
+        wrapper(1, 2, t=1)
+        # turn off
+        wrapper(1, 3, t=1)
+        # call 10 more times
+        for _ in range(10):
+            wrapper(1, 3, t=1)
+        
+        self.assertEqual(test['call_count'], 13)
+        
+    def test_cache_hit(self):
+        test = {'call_count':0}
+        def test_func(*args, **kwargs):
+            test['call_count'] += 1
+            
+        cache_decorator = function_cache(expected_max_entries=20)
+        wrapper = cache_decorator(test_func)
+        wrapper(1, 1, t=1)
+        wrapper(1, 2, t=1)
+        # turn off
+        wrapper(1, 3, t=1)
+        # call 10 more times
+        for _ in range(10):
+            wrapper(1, 3, t=1)
+            self.assertEqual(test['call_count'], 3)
+        
+        

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 import unittest
 import xml
+from nose.tools import raises
 from premailer.merge_style import csstext_to_pairs, merge_styles
 
 
@@ -9,14 +10,13 @@ class TestMergeStyle(unittest.TestCase):
     # should move them here
     # smaller files are easier to work with
     def test_csstext_to_pairs(self):
-        csstext = 'font-size:1px; color: red'
+        csstext = 'font-size:1px'
         parsed_csstext = csstext_to_pairs(csstext)
-        expected = [('color', 'red'), ('font-size', '1px')]
-        self.assertListEqual(expected, parsed_csstext)
+        self.assertEqual(('font-size', '1px'), parsed_csstext[0])
         
+    @raises(xml.dom.SyntaxErr)
     def test_inline_invalid_syntax(self):
         # inline shouldn't have those as I understand
         # but keep the behaviour
         inline = '{color:pink} :hover{color:purple} :active{color:red}'
-        with self.assertRaisesRegexp(xml.dom.SyntaxErr, 'CSSVariableDeclaration'):
-            merge_styles(inline, [], [])
+        merge_styles(inline, [], [])

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -6,7 +6,7 @@ from premailer.merge_style import csstext_to_pairs, merge_styles
 
 class TestMergeStyle(unittest.TestCase):
     # test what is not cover in test_premailer
-    # should romve them here
+    # should move them here
     # smaller files are easier to work with
     def test_csstext_to_pairs(self):
         csstext = 'font-size:1px; color: red'

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, unicode_literals
+import unittest
+import xml
+from premailer.merge_style import csstext_to_pairs, merge_styles
+
+
+class TestMergeStyle(unittest.TestCase):
+    # test what is not cover in test_premailer
+    # should romve them here
+    # smaller files are easier to work with
+    def test_csstext_to_pairs(self):
+        csstext = 'font-size:1px; color: red'
+        parsed_csstext = csstext_to_pairs(csstext)
+        expected = [('color', 'red'), ('font-size', '1px')]
+        self.assertListEqual(expected, parsed_csstext)
+        
+    def test_inline_invalid_syntax(self):
+        # inline shouldn't have those as I understand
+        # but keep the behaviour
+        inline = '{color:pink} :hover{color:purple} :active{color:red}'
+        with self.assertRaisesRegexp(xml.dom.SyntaxErr, 'CSSVariableDeclaration'):
+            merge_styles(inline, [], [])

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -20,6 +20,7 @@ from premailer.premailer import (
     transform,
     Premailer,
     merge_styles,
+    csstext_to_pairs,
     ExternalNotFoundError,
 )
 from premailer.__main__ import main
@@ -99,15 +100,15 @@ class Tests(unittest.TestCase):
         pass
 
     def test_merge_styles_basic(self):
-        old = 'font-size:1px; color: red'
+        inline_style = 'font-size:1px; color: red'
         new = 'font-size:2px; font-weight: bold'
-        expect = 'color:red;', 'font-size:2px;', 'font-weight:bold'
-        result = merge_styles(old, new)
+        expect = 'color:red;', 'font-size:1px;', 'font-weight:bold'
+        result = merge_styles(inline_style, [csstext_to_pairs(new)],[''])
         for each in expect:
             ok_(each in result)
 
     def test_merge_styles_with_class(self):
-        old = 'color:red; font-size:1px;'
+        inline_style = 'color:red; font-size:1px;'
         new, class_ = 'font-size:2px; font-weight: bold', ':hover'
 
         # because we're dealing with dicts (random order) we have to
@@ -115,7 +116,7 @@ class Tests(unittest.TestCase):
         # We expect something like this:
         #  {color:red; font-size:1px} :hover{font-size:2px; font-weight:bold}
 
-        result = merge_styles(old, new, class_)
+        result = merge_styles(inline_style, [csstext_to_pairs(new)], [class_])
         ok_(result.startswith('{'))
         ok_(result.endswith('}'))
         ok_(' :hover{' in result)
@@ -129,14 +130,14 @@ class Tests(unittest.TestCase):
             ok_(each in split_regex.findall(result)[1])
 
     def test_merge_styles_non_trivial(self):
-        old = 'background-image:url("data:image/png;base64,iVBORw0KGg")'
+        inline_style = 'background-image:url("data:image/png;base64,iVBORw0KGg")'
         new = 'font-size:2px; font-weight: bold'
         expect = (
             'background-image:url("data:image/png;base64,iVBORw0KGg")',
             'font-size:2px;',
             'font-weight:bold'
         )
-        result = merge_styles(old, new)
+        result = merge_styles(inline_style, [csstext_to_pairs(new)],[''])
         for each in expect:
             ok_(each in result)
 
@@ -607,7 +608,6 @@ class Tests(unittest.TestCase):
 
         p = Premailer(html, exclude_pseudoclasses=False)
         result_html = p.transform()
-
         # because we're dealing with random dicts here we can't predict what
         # order the style attribute will be written in so we'll look for
         # things manually.
@@ -621,6 +621,7 @@ class Tests(unittest.TestCase):
         self.fragment_in_html(e, result_html)
         e = ' :hover{border:1px solid green; text-decoration:none}'
         self.fragment_in_html(e, result_html)
+        
 
     def test_css_with_pseudoclasses_excluded(self):
         "Skip things like `a:hover{}` and keep them in the style block"
@@ -1576,21 +1577,21 @@ class Tests(unittest.TestCase):
 
             def run(self):
                 """Calls merge_styles in a loop and sets exc attribute if merge_styles raises an exception."""
-                for i in range(0, REPEATS):
+                for _ in range(0, REPEATS):
                     try:
                         merge_styles(self.old, self.new, self.class_)
                     except Exception as e:
                         logging.exception("Exception in thread %s", self.name)
                         self.exc = e
 
-        old = 'background-color:#ffffff;'
+        inline_style = 'background-color:#ffffff;'
         new = 'background-color:#dddddd;'
         class_ = ''
 
         # start multiple threads concurrently; each calls merge_styles many times
         threads = [
-            RepeatMergeStylesThread(old, new, class_)
-            for i in range(0, THREADS)
+            RepeatMergeStylesThread(inline_style, [csstext_to_pairs(new)], [class_])
+            for _ in range(0, THREADS)
         ]
         for t in threads:
             t.start()

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2237,3 +2237,36 @@ class Tests(unittest.TestCase):
         p = Premailer(html, disable_validation=True)
         result_html = p.transform()
         compare_html(expect_html, result_html)
+    
+    def test_turnoff_cache_works_as_expected(self):
+        html = """<html>
+        <head>
+        <style>
+        .color {
+            color: green;
+        }
+        div.example {
+            font-size: 10px;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="color example"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="color:green; font-size:10px"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, cache_css_parsing=False)
+        self.assertFalse(p.cache_css_parsing)
+        # run one time first
+        p.transform()
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)


### PR DESCRIPTION
We were entering problem with our emails which required 15-60s to process most of them and cpu usage was high, 100% cpu during those seconds. They take now around 0.4-1.5 seconds to process

After investigation I realize that inline styling didn't have a linear curve on time vs elements/classes. It multiply, I can not say what power is it but definitive some kind of exponential. For small amount it fast but when the mail is big and have complex rules it takes to much time.

Instead of converting rules to string and inserting into style-attribute and take it back again, parsing it with cssutils, merge and insert back to style-attribute, and repeat for many many run... (This is where time is multiplying) I collects all elements that we need to apply the rules on and apply rules for each of them in one goal.

Further more, our css are long and parse and go through rules on each of them take around 1-1.5 seconds. This is the reason I added a cache to gain around 80% of this time. It can be turned off for those who don't want it.

Here is a example code (thanks michaeljones) where the old code took 185.72238493s and new code took 5.29419207573s

https://gist.github.com/vanng822/ff706586bf6a91f3432d

Please take a look
Thank you