### PR TITLE
Disable pretty-printing by default for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also use premailer from the command line by using his main module.
     --disable-basic-attributes DISABLE_BASIC_ATTRIBUTES
                           Disable provided basic attributes (comma separated)
     --disable-validation  Disable CSSParser validation of attributes and values
-		--pretty              Pretty-print the outputted HTML.
+    --pretty              Pretty-print the outputted HTML.
 
 A basic example:
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ You can also use premailer from the command line by using his main module.
     --disable-basic-attributes DISABLE_BASIC_ATTRIBUTES
                           Disable provided basic attributes (comma separated)
     --disable-validation  Disable CSSParser validation of attributes and values
+		--pretty              Pretty-print the outputted HTML.
 
 A basic example:
 

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -101,6 +101,12 @@ def main(args):
         help="Disable CSSParser validation of attributes and values",
     )
 
+    parser.add_argument(
+        "--pretty", default=False,
+        action="store_true",
+        help="Pretty-print the outputted HTML.",
+    )
+
     options = parser.parse_args(args)
 
     if options.disable_basic_attributes:
@@ -128,7 +134,7 @@ def main(args):
         disable_basic_attributes=options.disable_basic_attributes,
         disable_validation=options.disable_validation
     )
-    options.outfile.write(p.transform())
+    options.outfile.write(p.transform(pretty_print=options.pretty))
     return 0
 
 


### PR DESCRIPTION
I don't see much reason for pretty-printing, it just introduces new whitespace that I've found to be problematic.  This patch disables pretty-pretty in the CLI, but it can be reenabled with the `--pretty` flag.