### PR TITLE
Always use UTF-8 for writing files, when running from the command line.

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -117,8 +117,9 @@ def main(args):
 
     if options.outfile is not sys.stdout:
         options.outfile.close()
-        options.outfile = codecs.open(options.outfile.name, 'w',
-                                      encoding='UTF-8')
+        options.outfile = codecs.open(
+            options.outfile.name, 'w', encoding='UTF-8'
+        )
 
     html = options.infile.read()
     if hasattr(html, 'decode'):  # Forgive me: Python 2 compatability

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -117,7 +117,8 @@ def main(args):
 
     if options.outfile is not sys.stdout:
         options.outfile.close()
-        options.outfile = codecs.open(options.outfile.name, 'w', encoding='UTF-8')
+        options.outfile = codecs.open(options.outfile.name, 'w',
+                                      encoding='UTF-8')
 
     html = options.infile.read()
     if hasattr(html, 'decode'):  # Forgive me: Python 2 compatability

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 import sys
 import argparse
+import codecs
 
 from .premailer import Premailer
 
@@ -113,6 +114,10 @@ def main(args):
         options.disable_basic_attributes = (
             options.disable_basic_attributes.split()
         )
+
+    if options.outfile is not sys.stdout:
+        options.outfile.close()
+        options.outfile = codecs.open(options.outfile.name, 'w', encoding='UTF-8')
 
     html = options.infile.read()
     if hasattr(html, 'decode'):  # Forgive me: Python 2 compatability


### PR DESCRIPTION
Python 2.x argparse.FileType doesn’t have an encoding= keyword parameter, so just re-open the file.

It’s not pretty, but it works.  If supporting only Python 3.4 and up, we can remove all this, and use argparse.FileType(‘w’, encoding=‘UTF-8’) above instead.

See bug #100.
