### PR TITLE
no need to convert readme markdown to structured text

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,6 @@ README = os.path.join(os.path.dirname(__file__), 'README.rst')
 long_description = open(README).read().strip() + "\n\n"
 
 
-def md2stx(s):
-    import re
-    s = re.sub(':\n(\s{8,10})', r'::\n\1', s)
-    return s
-
-long_description = md2stx(long_description)
-
-
 def find_version(*file_paths):
     version_file_path = os.path.join(os.path.dirname(__file__),
                                      *file_paths)


### PR DESCRIPTION
@graingert review? 
We no longer need this now that you converted the readme to reStructuredText. 