### PR TITLE
Avoid skipping links with media="all"

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -285,9 +285,9 @@ class Premailer(object):
 
         for element in CSSSelector('style,link[rel~=stylesheet]')(page):
             # If we have a media attribute whose value is anything other than
-            # 'screen', ignore the ruleset.
+            # 'all' or 'screen', ignore the ruleset.
             media = element.attrib.get('media')
-            if media and media != 'screen':
+            if media and media not in ('all', 'screen'):
                 continue
 
             data_attribute = element.attrib.get(self.attribute_name)


### PR DESCRIPTION
Links with `media="all"` target all devices [as the spec says](http://www.w3.org/TR/CSS2/media.html#media-types), but premailer only processes links with `media="screen"`.

For example, this `link` will be ignored, and it shouldn't:

```
        <link rel="stylesheet" media="all" type="text/css" href="styles.css">
```

Changed check to process media types `"all"` and `"screen"`.