### PR TITLE
Add support for adding align tags on images from css float

### DIFF
--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2419,3 +2419,37 @@ sheet" type="text/css">
         # Because you can't set a base_url without a full protocol
         p = Premailer(html, base_url='www.peterbe.com')
         assert_raises(ValueError, p.transform)
+
+    def test_align_float_images(self):
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style>
+        .floatright {
+            float: right;
+        }
+        </style>
+        </head>
+        <body>
+        <p><img src="/images/left.jpg" style="float: left"> text
+           <img src="/images/right.png" class="floatright"> text
+           <img src="/images/nofloat.gif"> text
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <p><img src="/images/left.jpg" style="float: left" align="left"> text
+           <img src="/images/right.png" style="float:right" align="right"> text
+           <img src="/images/nofloat.gif"> text
+        </p>
+        </body>
+        </html>"""
+
+        p = Premailer(html, align_floating_images=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)


### PR DESCRIPTION
Outlook (both on desktop and the web version) are notably bad at parsing CSS. One improvements if you want to use float on images is to use the align attribute instead of css float. Is this something that could be interesting to add into premailer? If so, then I'll clean up this pull request a bit, fix the code, and do some more testing.