### PR TITLE
add `unset_removes_attribute` option

### DIFF
--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -19,7 +19,12 @@ def csstext_to_pairs(csstext):
 csstext_to_pairs._lock = threading.RLock()
 
 
-def merge_styles(inline_style, new_styles, classes):
+def merge_styles(
+        inline_style,
+        new_styles,
+        classes,
+        remove_unset_properties=False
+):
     """
         This will merge all new styles where the order is important
         The last one will override the first
@@ -29,9 +34,12 @@ def merge_styles(inline_style, new_styles, classes):
 
         Args:
             inline_style(str): the old inline style of the element if there
-            is one new_styles: a list of new styles, each element should be
-            a list of tuple classes: a list of classes which maps
-            new_styles, important!
+                is one
+            new_styles: a list of new styles, each element should be
+                a list of tuple
+            classes: a list of classes which maps new_styles, important!
+            remove_unset_properties(bool): Allow us to remove certain CSS
+                properties with rules that set their value to 'unset'
 
         Returns:
             str: the final style
@@ -55,6 +63,13 @@ def merge_styles(inline_style, new_styles, classes):
     normal_styles = []
     pseudo_styles = []
     for pseudoclass, kv in styles.items():
+        if remove_unset_properties:
+            # Remove rules that we were going to have value 'unset' because
+            # they effectively are the same as not saying anything about the
+            # property when inlined
+            kv = dict(
+                (k, v) for (k, v) in kv.items() if not v.lower() == 'unset'
+            )
         if not kv:
             continue
         if pseudoclass:

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -143,6 +143,21 @@ class Tests(unittest.TestCase):
         for each in expect:
             ok_(each in result)
 
+    def test_merge_styles_with_unset(self):
+        inline_style = 'color: red'
+        new = 'font-size: 10px; font-size: unset; font-weight: bold'
+        expect = 'color:red;', 'font-weight:bold'
+        css_new = csstext_to_pairs(new)
+        result = merge_styles(
+            inline_style,
+            [css_new],
+            [''],
+            remove_unset_properties=True,
+        )
+        for each in expect:
+            ok_(each in result)
+        ok_('font-size' not in result)
+
     def test_basic_html(self):
         """test the simplest case"""
 
@@ -2451,5 +2466,38 @@ sheet" type="text/css">
         </html>"""
 
         p = Premailer(html, align_floating_images=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_remove_unset_properties(self):
+        html = """<html>
+        <head>
+        <style>
+        div {
+            color: green;
+        }
+        span {
+            color: blue;
+        }
+        span.nocolor {
+            color: unset;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="color"><span class="nocolor"></span></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="color:green"><span></span></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, remove_unset_properties=True)
+        self.assertTrue(p.remove_unset_properties)
         result_html = p.transform()
         compare_html(expect_html, result_html)


### PR DESCRIPTION
The purpose of this option is to give HTML email authors an easy way to reduce generated file size.

This option instructs premailer skip the inlining of CSS attributes that are set to `unset` because `unset` has effectively the same meaning as not inlining the property ([more](https://developer.mozilla.org/en-US/docs/Web/CSS/unset)). So a set of CSS rules that would previously have resulted in: `<p style="font-size: 14px; font-family: unset">` will instead result in `<p style="font-size: 14px">`, which should render exactly the same in all clients, but saves bytes. 

Support for `unset` is [not unviersal](http://caniuse.com/#feat=css-unset-value), but I don't this is a problem here. In my intended use of this feature, you would never actually see `unset` in the output from premailer. You could technically accomplish a similar thing by using a made-up property like `premailer-dont-inline-this` but it's a nice bonus that `unset` is a semi-official property with roughly the same meaning and is supported natively by Chrome and Firefox.

I created this as an off-by-default option to be conservative, but I actually think it could be merged into the core. Almost nobody is using `unset` in HTML emails, so for them this has no impact on the output. For people who are using it, this should only improve the output by removing a "meaningless" attribute that could confuse email clients.

By adding a couple of simple rules to our style sheet that look kinda like this:
```css
html body td.expander {
  /* expanders never contain text so font formatting is irrelevant */
  color: unset;
  font-family: unset;
  font-weight: unset;
  font-size: unset;
}
```
we took a 130kb reference newsletter (based on Zurb Ink) and shrunk it to 95kb. 