### PR TITLE
Support non ASCII characters on output

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -134,7 +134,12 @@ def main(args):
         disable_basic_attributes=options.disable_basic_attributes,
         disable_validation=options.disable_validation
     )
-    options.outfile.write(p.transform(pretty_print=options.pretty))
+    
+    output = p.transform(pretty_print=options.pretty)
+    if hasattr(output, 'encode'):  # Python 2 compatability
+        output = output.encode('utf-8')
+    options.outfile.write(output)
+    
     return 0
 
 


### PR DESCRIPTION
Without the encode step running in Python 2.7.10 (and probably other Python 2 versions) using the ```-o``` flag or redirecting the output with the ```>``` operator lead to a stack trace like

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/jhutchins/git/api/templates/env/lib/python2.7/site-packages/premailer/__main__.py", line 142, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/Users/jhutchins/git/api/templates/env/lib/python2.7/site-packages/premailer/__main__.py", line 137, in main
    options.outfile.write(p.transform(pretty_print=options.pretty))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 20719: ordinal not in range(128)
```