### PR TITLE
Add an option to capitalize margin and float properties

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -65,6 +65,12 @@ def main(args):
     )
 
     parser.add_argument(
+        "--capitalize-float-margin", default=False,
+        help="Capitalize float and margin properties for outlook.com compat.",
+        action="store_true", dest="capitalize_float_margin"
+    )
+
+    parser.add_argument(
         "--strip-important", default=False,
         help="Remove '!important' for all css declarations.",
         action="store_true", dest="strip_important"

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -16,9 +16,3 @@ class TestMergeStyle(unittest.TestCase):
         # Invalid syntax does not raise
         inline = '{color:pink} :hover{color:purple} :active{color:red}'
         merge_styles(inline, [], [])
-
-    def test_important_rule(self):
-        # No exception after #133
-        csstext = 'font-size:1px !important'
-        parsed_csstext = csstext_to_pairs(csstext)
-        self.assertEqual(('font-size', '1px'), parsed_csstext[0])

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -828,6 +828,45 @@ ical-align:middle" bgcolor="red" valign="middle">Cell 2</td>
 
         compare_html(expect_html, result_html)
 
+    def test_uppercase_margin(self):
+        """Option to comply with outlook.com
+
+        https://emailonacid.com/blog/article/email-development/outlook.com-does-support-margins
+        """
+
+        html = """<html>
+<head>
+<title>Title</title>
+</head>
+<style>
+h1 {margin: 0}
+h2 {margin-top:0;margin-bottom:0;margin-left:0;margin-right:0}
+</style>
+<body>
+<h1>a</h1>
+<h2>
+b
+</h2>
+</body>
+</html>"""
+
+        expect_html = """<html>
+<head>
+<title>Title</title>
+</head>
+<body>
+<h1 style="Margin:0">a</h1>
+<h2 style="Margin-bottom:0; Margin-left:0; Margin-right:0; Margin-top:0">
+b
+</h2>
+</body>
+</html>"""
+
+        p = Premailer(html, capitalize_float_margin=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
     def test_strip_important(self):
         """Get rid of !important. Makes no sense inline."""
         html = """<html>

--- a/premailer/tests/test_utils.py
+++ b/premailer/tests/test_utils.py
@@ -1,0 +1,19 @@
+import unittest
+
+from premailer.premailer import capitalize_float_margin
+
+
+class UtilsTestCase(unittest.TestCase):
+    def testcapitalize_float_margin(self):
+        self.assertEqual(
+            capitalize_float_margin('margin:1em'),
+            'Margin:1em')
+        self.assertEqual(
+            capitalize_float_margin('margin-left:1em'),
+            'Margin-left:1em')
+        self.assertEqual(
+            capitalize_float_margin('float:right;'),
+            'Float:right;')
+        self.assertEqual(
+            capitalize_float_margin('float:right;color:red;margin:0'),
+            'Float:right;color:red;Margin:0')


### PR DESCRIPTION
The option is disabled by default, that weird idea comes from a weird
outlook.com behaviour to handle margin and float properties only if the
first letter is uppercase.

See https://www.emailonacid.com/blog/article/email-development/outlook.com-does-support-margins

Feel free to give me some leads/hints if my approach is not good, but regexps is (sadly) the better I found that didn't required to modify *cssutils* and folks.