### PR TITLE
When merge style, don't change the style items' order

### DIFF
--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import, unicode_literals
 from .premailer import Premailer, transform
 
-__version__ = '2.9.6'
+__version__ = '2.9.7'

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -7,6 +7,7 @@ except ImportError:  # pragma: no cover
     # some old python 2.6 thing then, eh?
     from ordereddict import OrderedDict
 
+
 def csstext_to_pairs(csstext):
     """
     csstext_to_pairs takes css text and make it to list of

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -1,7 +1,11 @@
 import cssutils
 import threading
 from operator import itemgetter
-
+try:
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    # some old python 2.6 thing then, eh?
+    from ordereddict import OrderedDict
 
 def csstext_to_pairs(csstext):
     """
@@ -49,9 +53,9 @@ def merge_styles(
             str: the final style
     """
     # building classes
-    styles = {'': {}}
+    styles = OrderedDict([('', OrderedDict())])
     for pc in set(classes):
-        styles[pc] = {}
+        styles[pc] = OrderedDict()
 
     for i, style in enumerate(new_styles):
         for k, v in style:
@@ -71,7 +75,7 @@ def merge_styles(
             # Remove rules that we were going to have value 'unset' because
             # they effectively are the same as not saying anything about the
             # property when inlined
-            kv = dict(
+            kv = OrderedDict(
                 (k, v) for (k, v) in kv.items() if not v.lower() == 'unset'
             )
         if not kv:
@@ -80,12 +84,12 @@ def merge_styles(
             pseudo_styles.append(
                 '%s{%s}' % (
                     pseudoclass,
-                    '; '.join('%s:%s' % (k, v) for k, v in sorted(kv.items()))
+                    '; '.join('%s:%s' % (k, v) for k, v in kv.items())
                 )
             )
         else:
             normal_styles.append('; '.join(
-                '%s:%s' % (k, v) for k, v in sorted(kv.items())
+                '%s:%s' % (k, v) for k, v in kv.items()
             ))
 
     if pseudo_styles:

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -548,8 +548,10 @@ class Premailer(object):
                 attributes['align'] = value.strip()
             elif key == 'vertical-align':
                 attributes['valign'] = value.strip()
-            elif ((key == 'background-color')
-                  and ('transparent' not in value.lower())):
+            elif (
+                key == 'background-color' and
+                'transparent' not in value.lower()
+            ):
                 # Only add the 'bgcolor' attribute if the value does not
                 # contain the word "transparent"; before we add it possibly
                 # correct the 3-digit color code to its 6-digit equivalent

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -102,7 +102,7 @@ class Tests(unittest.TestCase):
     def test_merge_styles_basic(self):
         inline_style = 'font-size:1px; color: red'
         new = 'font-size:2px; font-weight: bold'
-        expect = 'color:red;', 'font-size:1px;', 'font-weight:bold'
+        expect = 'font-size:1px;', 'font-weight:bold;', 'color:red'
         result = merge_styles(inline_style, [csstext_to_pairs(new)], [''])
         for each in expect:
             ok_(each in result)
@@ -146,7 +146,7 @@ class Tests(unittest.TestCase):
     def test_merge_styles_with_unset(self):
         inline_style = 'color: red'
         new = 'font-size: 10px; font-size: unset; font-weight: bold'
-        expect = 'color:red;', 'font-weight:bold'
+        expect = 'font-weight:bold;', 'color:red'
         css_new = csstext_to_pairs(new)
         result = merge_styles(
             inline_style,
@@ -632,11 +632,11 @@ ple.com/bg.png); color:#123; font-family:Omerta">
             'Paragraph</p>'
         self.fragment_in_html(e, result_html, True)
 
-        e = 'style="{border:1px solid green; color:red}'
+        e = 'style="{color:red; border:1px solid green}'
         self.fragment_in_html(e, result_html)
         e = ' :visited{border:1px solid green}'
         self.fragment_in_html(e, result_html)
-        e = ' :hover{border:1px solid green; text-decoration:none}'
+        e = ' :hover{text-decoration:none; border:1px solid green}'
         self.fragment_in_html(e, result_html)
 
     def test_css_with_pseudoclasses_excluded(self):
@@ -666,7 +666,7 @@ a:visited {border:1px solid green}p::first-letter {float:left;font-size:300%}
 </style>
 </head>
 <body>
-<a href="#" style="border:1px solid green; color:red">Page</a>
+<a href="#" style="color:red; border:1px solid green">Page</a>
 <p>Paragraph</p>
 </body>
 </html>"""
@@ -1196,7 +1196,7 @@ ical-align:middle" bgcolor="red" valign="middle">Cell 2</td>
         <head>
         </head>
         <body>
-        <div id="identified" style="color:blue; font-size:22px"></div>
+        <div id="identified" style="font-size:22px; color:blue"></div>
         </body>
         </html>"""
 
@@ -2246,7 +2246,7 @@ ent:"" !important;display:block !important}
 
         p = Premailer(html)
         result = p.transform()
-        eq_(type(result), type(""))
+        eq_(type(result), type(u""))
 
         html = fromstring(html)
         etree_type = type(html)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2246,7 +2246,7 @@ ent:"" !important;display:block !important}
 
         p = Premailer(html)
         result = p.transform()
-        eq_(type(result), type(u""))
+        eq_(type(result), type(""))
 
         html = fromstring(html)
         etree_type = type(html)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2501,3 +2501,37 @@ sheet" type="text/css">
         self.assertTrue(p.remove_unset_properties)
         result_html = p.transform()
         compare_html(expect_html, result_html)
+
+    def test_six_color(self):
+        r = Premailer.six_color('#cde')
+        e = '#ccddee'
+        self.assertEqual(e, r)
+
+    def test_3_digit_color_expand(self):
+        'Are 3-digit color values expanded into 6-digits for IBM Notes'
+        html = """<html>
+    <style>
+        body {background-color: #fe5;}
+        p {background-color: #123456;}
+        h1 {color: #f0df0d;}
+    </style>
+    <body>
+        <h1>color test</h1>
+        <p>
+            This is a test of color handling.
+        </p>
+    </body>
+</html>"""
+        expect_html = """<html>
+    <head>
+    </head>
+    <body style="background-color:#fe5" bgcolor="#ffee55">
+        <h1 style="color:#f0df0d">color test</h1>
+        <p style="background-color:#123456" bgcolor="#123456">
+            This is a test of color handling.
+        </p>
+    </body>
+</html>"""
+        p = Premailer(html, remove_unset_properties=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)

--- a/tox.ini
+++ b/tox.ini
@@ -57,3 +57,16 @@ deps =
     ordereddict
     argparse
     coverage
+
+
+[testenv:pypy]
+# pypy can't be built with >3.4.4 so, in tox we pin back to the last
+# known good version of lxml
+deps =
+    setuptools
+    nose
+    mock
+    cssselect
+    cssutils
+    lxml==3.4.4
+    coverage


### PR DESCRIPTION
#### A original test page:
```
<html>
<head>
    <style>
        .bg1 { background: red; }
        .bg2 { background-color: blue; }
        .bg3 { background-color: blue; }
        .bg4 { background: red; }
    </style>
</head>
<body>
    <h1 class="bg1 bg2">Hello World1!</h1>
    <h1 class="bg3 bg4">Hello World2!</h1>
</body>
</html>
```

When it open by browser:
background color of the **first h1 tag** is **blue**
background color of the **second h1 tag** is **red**

***
#### After use premailer, page change to:
```
<html>
<head>
    </head>
<body>
    <h1 class="bg1 bg2" style="background:red; background-color:blue" bgcolor="blue">Hello World1!</h1>
    <h1 class="bg3 bg4" style="background:red; background-color:blue" bgcolor="blue">Hello World2!</h1>
</body>
</html>
```
When it open by browser:
background color of the **first h1 tag** is **blue**
background color of the **second h1 tag** is **blue**
***
> Because premailer change the style order (premailer will sort the style items according alphabetical order)
> This patch will fix this issue, it does not deliberately to sort the style items.