### PR TITLE
Add Python 3.5 to tox and travis and drop Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - TOX_ENV=flake8
   - TOX_ENV=py26
   - TOX_ENV=py27
-  - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ before_install:
 install:
   - travis_retry python setup.py install
 
+# See https://github.com/travis-ci/travis-ci/issues/4794
+# and https://github.com/audreyr/cookiecutter/pull/540/files
+python: 3.5
+
 env:
   - TOX_ENV=flake8
   - TOX_ENV=py26
@@ -27,6 +31,7 @@ env:
   - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=pypy
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ makes sure premailer works in:
 
 -  Python 2.6
 -  Python 2.7
--  Python 3.2
 -  Python 3.3
 -  Python 3.4
 -  Python 3.5

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ makes sure premailer works in:
 -  Python 3.2
 -  Python 3.3
 -  Python 3.4
+-  Python 3.5
 -  PyPy
 
 Turns CSS blocks into style attributes

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -27,7 +27,7 @@ else:  # Python 2
         StringIO = StringIO  # shut up pyflakes
     from urllib2 import urlopen
     from urlparse import urljoin, urlparse
-    STR_TYPE = basestring
+    STR_TYPE = basestring  # NOQA
 
 import cssutils
 from lxml import etree
@@ -634,4 +634,4 @@ if __name__ == '__main__':  # pragma: no cover
         </body>
         </html>"""
     p = Premailer(html)
-    print (p.transform())
+    print(p.transform())

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py26, py27, py32, py33, py34, py35, pypy
+envlist = flake8, py26, py27, py33, py34, py35, pypy
 
 [testenv]
 passenv = *
@@ -24,21 +24,6 @@ deps =
 [testenv:flake8]
 deps = flake8
 commands = flake8 premailer
-
-[testenv:py32]
-# Python 3.2 does not support coverage 4.x
-commands = nosetests --with-coverage --cover-package=premailer
-install_command =
-  pip install {opts} {packages}
-
-deps =
-    setuptools
-    nose
-    mock
-    cssselect
-    cssutils
-    lxml
-    coverage==3.7.1
 
 [testenv:py26]
 # Python 2.6 is missing both the ordereddict and argparse modules

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py26, py27, py32, py33, py34, pypy
+envlist = flake8, py26, py27, py32, py33, py34, py35, pypy
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Works out of the box for me on OSX El Capitan, let's see what Travis says.