### PR TITLE
Unicode, e.g. crescent moon 🌙  & beers 🍻 breaks under Python 3

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -462,7 +462,8 @@ class Premailer(object):
             kwargs.setdefault('method', self.method)
             kwargs.setdefault('pretty_print', pretty_print)
             kwargs.setdefault('encoding', 'utf-8')  # As Ken Thompson intended
-            out = etree.tostring(root, **kwargs).decode(kwargs['encoding'])
+            out_bytes = etree.tostring(root, **kwargs)
+            out = out_bytes.decode(kwargs['encoding'])
             if self.method == 'xml':
                 out = _cdata_regex.sub(
                     lambda m: '/*<![CDATA[*/%s/*]]>*/' % m.group(1),

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2226,6 +2226,23 @@ ent:"" !important;display:block !important}
         p.transform()  # it should work
         eq_(mylog.getvalue(), '')
 
+    def test_unicode_crescent_moon_0x1f319(self):
+        html = '''<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+            Dear Skyelar 🌙,
+</body>
+</html>
+'''
+        p = Premailer(html)
+
+        # Calling transform should not mangle
+        # the unicode character 🌙
+        mojibake = p.transform()
+        compare_html(mojibake, html)
+
     def test_type_test(self):
         """test the correct type is returned"""
 

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import sys
 import re


### PR DESCRIPTION
As suggested by @peterbe on #157, please see for more details.

Not sure how to proceed so if anyone can make the test pass, go for it and good on you :+1: 