### PR TITLE
require requests instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ env:
 script:
   - tox -e $TOX_ENV
 
+branches:
+  only:
+  - master
+
 after_success:
   # Report coverage results to coveralls.io
   - coveralls

--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import, unicode_literals
 from .premailer import Premailer, transform
 
-__version__ = '2.9.8'
+__version__ = '2.10.0'

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import, unicode_literals, print_function
-from io import BytesIO  # Yes, there is an io module in Python 2
-import cgi
 import codecs
-import gzip
 import operator
 import os
 import re
@@ -16,7 +13,6 @@ import sys
 if sys.version_info >= (3,):  # pragma: no cover
     # As in, Python 3
     from io import StringIO
-    from urllib.request import urlopen
     from urllib.parse import urljoin, urlparse
     STR_TYPE = str
 else:  # Python 2
@@ -25,11 +21,11 @@ else:  # Python 2
     except ImportError:  # pragma: no cover
         from StringIO import StringIO
         StringIO = StringIO  # shut up pyflakes
-    from urllib2 import urlopen
     from urlparse import urljoin, urlparse
     STR_TYPE = basestring  # NOQA
 
 import cssutils
+import requests
 from lxml import etree
 from lxml.cssselect import CSSSelector
 from premailer.merge_style import merge_styles, csstext_to_pairs
@@ -473,16 +469,7 @@ class Premailer(object):
             return out
 
     def _load_external_url(self, url):
-        r = urlopen(url)
-        _, params = cgi.parse_header(r.headers.get('Content-Type', ''))
-        encoding = params.get('charset', 'utf-8')
-        if 'gzip' in r.info().get('Content-Encoding', ''):
-            buf = BytesIO(r.read())
-            f = gzip.GzipFile(fileobj=buf)
-            out = f.read().decode(encoding)
-        else:
-            out = r.read().decode(encoding)
-        return out
+        return requests.get(url).text
 
     def _load_external(self, url):
         """loads an external stylesheet from a remote url or local path

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     'lxml',
     'cssselect',
     'cssutils',
+    'requests',
 ]
 if sys.version_info >= (2, 6) and sys.version_info <= (2, 7):
     # Python 2.6 is the oldest version we support and it


### PR DESCRIPTION
`urllib` is more or less dead compared to `requests`. Especially for python 2.