### PR TITLE
Inline Important Tags

### DIFF
--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -8,6 +8,13 @@ except ImportError:  # pragma: no cover
     from ordereddict import OrderedDict
 
 
+def format_value(prop):
+    if prop.priority == "important":
+        return prop.propertyValue.cssText.strip() + ' !important'
+    else:
+        return prop.propertyValue.cssText.strip()
+
+
 def csstext_to_pairs(csstext):
     """
     csstext_to_pairs takes css text and make it to list of
@@ -18,7 +25,7 @@ def csstext_to_pairs(csstext):
     with csstext_to_pairs._lock:
         return sorted(
             [
-                (prop.name.strip(), prop.propertyValue.cssText.strip())
+                (prop.name.strip(), format_value(prop))
                 for prop in cssutils.parseStyle(csstext)
             ],
             key=itemgetter(0)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -185,12 +185,18 @@ class Premailer(object):
         The bulk of the rule should not end in a semicolon.
         """
 
+        def format_css_property(prop):
+            if self.strip_important or prop.priority != 'important':
+                return '{0}:{1}'.format(prop.name, prop.value)
+            else:
+                return '{0}:{1} !important'.format(prop.name, prop.value)
+
         def join_css_properties(properties):
             """ Accepts a list of cssutils Property objects and returns
             a semicolon delimitted string like 'color: red; font-size: 12px'
             """
             return ';'.join(
-                '{0}:{1}'.format(prop.name, prop.value)
+                format_css_property(prop)
                 for prop in properties
             )
 

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2540,3 +2540,34 @@ sheet" type="text/css">
         p = Premailer(html, remove_unset_properties=True)
         result_html = p.transform()
         compare_html(expect_html, result_html)
+
+    def test_inline_important(self):
+        'Are !important tags preserved inline.'
+
+        html = """<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <style type="text/css">.something { display:none !important; }</style>
+  <div class="something">blah</div>
+</body>
+</html>"""
+
+        expect_html = """<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <style type="text/css">.something { display:none !important; }</style>
+  <div class="something" style="display:none !important">blah</div>
+</body>
+</html>"""
+        p = Premailer(
+            html,
+            remove_classes=False,
+            keep_style_tags=True,
+            strip_important=False
+        )
+        result_html = p.transform()
+        compare_html(expect_html, result_html)


### PR DESCRIPTION
In association with this issue: https://github.com/peterbe/premailer/issues/164

I finally figured it out.

The important tag wasnt getting preserved, so I had to carry it along in the css property value.

I couldnt get `tox` to work, but this here's an example:

```py
from premailer import Premailer

html = """
<html>
<head>
  <title></title>
</head>
<body>
  <style type="text/css">.something { display:none !important; }</style>
  <div class="something">blah</div>
</body>
</html>
"""

import ipdb; ipdb.set_trace()
print Premailer(html, remove_classes=False, 
                      keep_style_tags=True, 
                      strip_important=True).transform()

# <html>
# <head>
#   <title></title>
# </head>
# <body>
#   <style type="text/css">.something { display:none !important; }</style>
#   <div class="something" style="display:none">blah</div>
# </body>
# </html>
```

```py
from premailer import Premailer

html = """
<html>
<head>
  <title></title>
</head>
<body>
  <style type="text/css">.something { display:none !important; }</style>
  <div class="something">blah</div>
</body>
</html>
"""

import ipdb; ipdb.set_trace()
print Premailer(html, remove_classes=False, 
                      keep_style_tags=True, 
                      strip_important=False).transform()

# <html>
# <head>
#   <title></title>
# </head>
# <body>
#   <style type="text/css">.something { display:none !important; }</style>
#   <div class="something" style="display:none !important">blah</div>
# </body>
# </html>
```
