### PR TITLE
Allow setting encoding from command-line.

### DIFF
--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -112,6 +112,11 @@ def main(args):
         action="store_true",
         help="Pretty-print the outputted HTML.",
     )
+    
+    parser.add_argument(
+        "--encoding", default='utf-8',
+        help="Output encoding. The default is utf-8",
+    )
 
     options = parser.parse_args(args)
 
@@ -140,7 +145,7 @@ def main(args):
         disable_basic_attributes=options.disable_basic_attributes,
         disable_validation=options.disable_validation
     )
-    options.outfile.write(p.transform(pretty_print=options.pretty))
+    options.outfile.write(p.transform(encoding=options.encoding, pretty_print=options.pretty))
     return 0
 
 

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -112,7 +112,7 @@ def main(args):
         action="store_true",
         help="Pretty-print the outputted HTML.",
     )
-    
+
     parser.add_argument(
         "--encoding", default='utf-8',
         help="Output encoding. The default is utf-8",
@@ -145,7 +145,10 @@ def main(args):
         disable_basic_attributes=options.disable_basic_attributes,
         disable_validation=options.disable_validation
     )
-    options.outfile.write(p.transform(encoding=options.encoding, pretty_print=options.pretty))
+    options.outfile.write(p.transform(
+        encoding=options.encoding,
+        pretty_print=options.pretty
+    ))
     return 0
 
 


### PR DESCRIPTION
Passing `--encoding ascii` should fix issues #93, #100, #152 and #157.