### PR TITLE
Raising an error on external style 404s

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -505,7 +505,7 @@ class Premailer(object):
 
     def _load_external_url(self, url):
         r = requests.get(url)
-        if r.status_code == 400:
+        if r.status_code == 404:
             raise ExternalNotFoundError(url)
         return r.text
 

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -504,7 +504,10 @@ class Premailer(object):
             return out
 
     def _load_external_url(self, url):
-        return requests.get(url).text
+        r = requests.get(url)
+        if r.status_code == 400:
+            raise ExternalNotFoundError(url)
+        return r.text
 
     def _load_external(self, url):
         """loads an external stylesheet from a remote url or local path

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -1829,7 +1829,7 @@ ent:"" !important;display:block !important}
         mocked_requests.get.assert_called_once_with(faux_uri)
         eq_(faux_response, r)
 
-    @mock.path('premailer.premailer.requests')
+    @mock.patch('premailer.premailer.requests')
     def test_load_external_url_w_404(self, mocked_requests):
         'Test premailer.premailer.Premailer._load_external_url with a 404'
         faux_response = 'This is not a response'

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -54,8 +54,9 @@ def provide_input(content):
 
 class MockResponse(object):
 
-    def __init__(self, content):
+    def __init__(self, content, status_code=200):
         self.text = content
+        self.status_code = status_code
 
 
 def compare_html(one, two):
@@ -1827,6 +1828,19 @@ ent:"" !important;display:block !important}
 
         mocked_requests.get.assert_called_once_with(faux_uri)
         eq_(faux_response, r)
+
+    @mock.path('premailer.premailer.requests')
+    def test_load_external_url_w_404(self, mocked_requests):
+        'Test premailer.premailer.Premailer._load_external_url with a 404'
+        faux_response = 'This is not a response'
+        faux_uri = 'https://example.com/site.css'
+        mocked_requests.get.return_value = MockResponse(faux_response, 404)
+        p = premailer.premailer.Premailer('<p>A paragraph</p>')
+        assert_raises(
+            ExternalNotFoundError,
+            p._load_external_url,
+            faux_uri
+        )
 
     def test_css_text(self):
         """Test handling css_text passed as a string"""


### PR DESCRIPTION
If you give premailer an external stylesheet that 404s, it should raise an ExternalNotFoundError. Otherwise, it will attempt to parse the 404 page as a CSS file and give you some funky errors.
