### PR TITLE
Add option to preserve all links in html

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -116,6 +116,7 @@ class Premailer(object):
     attribute_name = 'data-premailer'
 
     def __init__(self, html, base_url=None,
+                 preserve_all_links=False,
                  preserve_internal_links=False,
                  preserve_inline_attachments=True,
                  exclude_pseudoclasses=True,
@@ -138,6 +139,14 @@ class Premailer(object):
                  remove_unset_properties=True):
         self.html = html
         self.base_url = base_url
+
+        # if base_url is specified, premailer will transform all URLs by joining
+        # them with the base_url. Setting preserve_internal_links to True
+        # will disable this behavior for links to named anchors. Setting
+        # preserve_inline_attachments to True will disable this behavior for
+        # any links with cid: scheme. Setting preserve_all_links to True will
+        # disable this behavior altogether.
+        self.preserve_all_links = preserve_all_links
         self.preserve_internal_links = preserve_internal_links
         self.preserve_inline_attachments = preserve_inline_attachments
         self.exclude_pseudoclasses = exclude_pseudoclasses
@@ -473,7 +482,7 @@ class Premailer(object):
         #
         # URLs
         #
-        if self.base_url:
+        if self.base_url and not self.preserve_all_links:
             if not urlparse(self.base_url).scheme:
                 raise ValueError('Base URL must have a scheme')
             for attr in ('href', 'src'):

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -140,9 +140,9 @@ class Premailer(object):
         self.html = html
         self.base_url = base_url
 
-        # if base_url is specified, premailer will transform all URLs by joining
-        # them with the base_url. Setting preserve_internal_links to True
-        # will disable this behavior for links to named anchors. Setting
+        # if base_url is specified, premailer will transform all URLs by
+        # joining them with the base_url. Setting preserve_internal_links to
+        # True will disable this behavior for links to named anchors. Setting
         # preserve_inline_attachments to True will disable this behavior for
         # any links with cid: scheme. Setting preserve_all_links to True will
         # disable this behavior altogether.

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -116,7 +116,7 @@ class Premailer(object):
     attribute_name = 'data-premailer'
 
     def __init__(self, html, base_url=None,
-                 preserve_all_links=False,
+                 disable_link_rewrites=False,
                  preserve_internal_links=False,
                  preserve_inline_attachments=True,
                  exclude_pseudoclasses=True,
@@ -140,13 +140,16 @@ class Premailer(object):
         self.html = html
         self.base_url = base_url
 
-        # if base_url is specified, premailer will transform all URLs by
+        # If base_url is specified, it is used for loading external stylesheets
+        # via relative URLs.
+        #
+        # Also, if base_url is specified, premailer will transform all URLs by
         # joining them with the base_url. Setting preserve_internal_links to
         # True will disable this behavior for links to named anchors. Setting
         # preserve_inline_attachments to True will disable this behavior for
-        # any links with cid: scheme. Setting preserve_all_links to True will
-        # disable this behavior altogether.
-        self.preserve_all_links = preserve_all_links
+        # any links with cid: scheme. Setting disable_link_rewrites to True
+        # will disable this behavior altogether.
+        self.disable_link_rewrites = disable_link_rewrites
         self.preserve_internal_links = preserve_internal_links
         self.preserve_inline_attachments = preserve_inline_attachments
         self.exclude_pseudoclasses = exclude_pseudoclasses
@@ -482,7 +485,7 @@ class Premailer(object):
         #
         # URLs
         #
-        if self.base_url and not self.preserve_all_links:
+        if self.base_url and not self.disable_link_rewrites:
             if not urlparse(self.base_url).scheme:
                 raise ValueError('Base URL must have a scheme')
             for attr in ('href', 'src'):

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -576,7 +576,7 @@ ple.com/bg.png); color:#123; font-family:Omerta">
 
     def test_base_url_ignore_links(self):
         """if you leave some URLS as /foo, set base_url to
-        'http://www.google.com' and set preserve_all_links to True, the URLS
+        'http://www.google.com' and set disable_link_rewrites to True, the URLS
         should not be changed.
         """
 
@@ -612,7 +612,7 @@ ple.com/bg.png); color:#123; font-family:Omerta">
         </html>'''
 
         p = Premailer(html, base_url='http://kungfupeople.com/base/',
-                      preserve_all_links=True)
+                      disable_link_rewrites=True)
         result_html = p.transform()
 
         compare_html(expect_html, result_html)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -574,6 +574,49 @@ ple.com/bg.png); color:#123; font-family:Omerta">
 
         compare_html(expect_html, result_html)
 
+    def test_base_url_ignore_links(self):
+        """if you leave some URLS as /foo, set base_url to
+        'http://www.google.com' and set preserve_all_links to True, the URLS
+        should not be changed.
+        """
+
+        html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>
+        '''
+
+        expect_html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>'''
+
+        p = Premailer(html, base_url='http://kungfupeople.com/base/',
+                      preserve_all_links=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
     def test_shortcut_function(self):
         # you don't have to use this approach:
         #   from premailer import Premailer


### PR DESCRIPTION
We are trying to use this great module in cppreference-doc project for creating browsable HTML documentation for various help viewers. One of them does not support external CSS nor style tags, thus your project is very handy.

Unfortunately current URL processing in premailer breaks relative links between pages. I've added an option to disable this. Can this change be included into the official premailer project?