### PR TITLE
Explicitly list python versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,26 @@ before_install:
 install:
   - travis_retry python setup.py install
 
-# See https://github.com/travis-ci/travis-ci/issues/4794
-# and https://github.com/audreyr/cookiecutter/pull/540/files
-python: 3.5
+# pypy is not installed on trusty-based containers by default.
+# See https://github.com/travis-ci/travis-ci/issues/6865
 
-env:
-  - TOX_ENV=flake8
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=pypy
+matrix:
+  include:
+    - python: "3.5"
+      env: TOX_ENV=flake8
+    - python: "2.6"
+      env: TOX_ENV=py26
+    - python: "2.7"
+      env: TOX_ENV=py27
+    - python: "3.3"
+      env: TOX_ENV=py33
+    - python: "3.4"
+      env: TOX_ENV=py34
+    - python: "3.5"
+      env: TOX_ENV=py35
+    # just using pypy2.7 does not work due to travis pypy packaging issues
+    - python: "pypy2.7-5.10.0"
+      env: TOX_ENV=pypy
 
 script:
   - tox -e $TOX_ENV


### PR DESCRIPTION
Due to https://github.com/travis-ci/travis-ci/issues/6865 pypy is not installed by default (See https://travis-ci.org/peterbe/premailer/jobs/361610913). This PR attempts to fix that.