### PR TITLE
Added support for `data-premailer="ignore"` HTML attribute

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -329,7 +329,11 @@ class Premailer(object):
         rules = []
         index = 0
 
-        for element in CSSSelector('style,link[rel~=stylesheet]')(page):
+        selectors = [
+            'style:not([data-premailer="ignore"])',
+            'link[rel~=stylesheet]:not([data-premailer="ignore"])'
+        ]
+        for element in CSSSelector(','.join(selectors))(page):
             # If we have a media attribute whose value is anything other than
             # 'all' or 'screen', ignore the ruleset.
             media = element.attrib.get('media')


### PR DESCRIPTION
`<style>` and `<link>` tags with this attribute will be ignored by Premailer, allowing you to skip inlining for things like Google fonts stylesheets. This is the method used by the Ruby Premailer script:

https://github.com/premailer/premailer/#premailer-specific-css

Closes #196.