### PR TITLE
Add caching to more functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,8 @@ matrix:
   include:
     - python: "3.5"
       env: TOX_ENV=flake8
-    - python: "2.6"
-      env: TOX_ENV=py26
     - python: "2.7"
       env: TOX_ENV=py27
-    - python: "3.3"
-      env: TOX_ENV=py33
     - python: "3.4"
       env: TOX_ENV=py34
     - python: "3.5"

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -21,31 +21,21 @@ class _Cache(object):
         self.cache = {}
 
 
-def function_cache(expected_max_entries=1000):
+def function_cache():
     """
-        function_cache is a decorator for caching function call
-        the argument to the wrapped function must be hashable else
+        function_cache is a decorator for caching function call.
+        The argument to the wrapped function must be hashable else
         it will not work
 
-        expected_max_entries is for protecting cache failure. If cache
-        misses more than this number the cache will turn off itself.
-        Specify None you sure that the cache  will not cause memory
-        limit problem.
-
-        Args:
-            expected_max_entries(integer OR None): will raise if not correct
+        Function wrapper accepts max_cache_entries argument which is for
+        protecting against cache failure. If cache misses more than this number
+        the cache will turn off itself. Specifying None will not limit cache
+        at all.
 
         Returns:
             function
 
     """
-    if (
-        expected_max_entries is not None and
-        not isinstance(expected_max_entries, int)
-    ):
-        raise TypeError(
-            'Expected expected_max_entries to be an integer or None'
-        )
 
     # indicator of cache missed
     sentinel = object()
@@ -55,7 +45,17 @@ def function_cache(expected_max_entries=1000):
 
         @functools.wraps(func)
         def inner(*args, **kwargs):
-            if cached.off:
+            max_cache_entries = kwargs.pop('max_cache_entries', 1000)
+
+            if (
+                max_cache_entries is not None and
+                not isinstance(max_cache_entries, int)
+            ):
+                raise TypeError(
+                    'Expected expected_max_entries to be an integer or None'
+                )
+
+            if cached.off or max_cache_entries == 0:
                 return func(*args, **kwargs)
 
             keys = args
@@ -73,8 +73,8 @@ def function_cache(expected_max_entries=1000):
                 # # something is wrong if we are here more than expected
                 # # empty and turn it off
                 if (
-                    expected_max_entries is not None and
-                    cached.missed > expected_max_entries
+                    max_cache_entries is not None and
+                    cached.missed > max_cache_entries
                 ):
                     cached.off = True
                     cached.cache.clear()

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -43,7 +43,7 @@ def function_cache():
                 not isinstance(max_cache_entries, int)
             ):
                 raise TypeError(
-                    'Expected expected_max_entries to be an integer or None'
+                    'Expected max_cache_entries to be an integer or None'
                 )
 
             if max_cache_entries == 0:

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -1,18 +1,6 @@
 import functools
 
 
-class _HashedSeq(list):
-    # # From CPython
-    __slots__ = 'hashvalue'
-
-    def __init__(self, tup, hash=hash):
-        self[:] = tup
-        self.hashvalue = hash(tup)
-
-    def __hash__(self):
-        return self.hashvalue
-
-
 def function_cache():
     """
         function_cache is a decorator for caching function call.
@@ -49,13 +37,19 @@ def function_cache():
             if max_cache_entries == 0:
                 return func(*args, **kwargs)
 
-            keys = args
+            keys = []
+            for arg in args:
+                if isinstance(arg, list):
+                    keys.append(tuple(arg))
+                else:
+                    keys.append(arg)
+
             if kwargs:
                 sorted_items = sorted(kwargs.items())
                 for item in sorted_items:
-                    keys += item
+                    keys.append(item)
 
-            hashed = hash(_HashedSeq(keys))
+            hashed = hash(tuple(keys))
             result = cache.get(hashed, sentinel)
             if result is sentinel:
                 result = func(*args, **kwargs)

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -13,24 +13,15 @@ class _HashedSeq(list):
         return self.hashvalue
 
 
-# if we only have nonlocal
-class _Cache(object):
-    def __init__(self):
-        self.off = False
-        self.missed = 0
-        self.cache = {}
-
-
 def function_cache():
     """
         function_cache is a decorator for caching function call.
         The argument to the wrapped function must be hashable else
         it will not work
 
-        Function wrapper accepts max_cache_entries argument which is for
-        protecting against cache failure. If cache misses more than this number
-        the cache will turn off itself. Specifying None will not limit cache
-        at all.
+        Function wrapper accepts max_cache_entries argument which specifies
+        the maximum number of different data to cache. Specifying None will not
+        limit the size of the cache at all.
 
         Returns:
             function
@@ -41,7 +32,7 @@ def function_cache():
     sentinel = object()
 
     def decorator(func):
-        cached = _Cache()
+        cache = {}
 
         @functools.wraps(func)
         def inner(*args, **kwargs):
@@ -55,7 +46,7 @@ def function_cache():
                     'Expected expected_max_entries to be an integer or None'
                 )
 
-            if cached.off or max_cache_entries == 0:
+            if max_cache_entries == 0:
                 return func(*args, **kwargs)
 
             keys = args
@@ -65,19 +56,12 @@ def function_cache():
                     keys += item
 
             hashed = hash(_HashedSeq(keys))
-            result = cached.cache.get(hashed, sentinel)
+            result = cache.get(hashed, sentinel)
             if result is sentinel:
-                cached.missed += 1
                 result = func(*args, **kwargs)
-                cached.cache[hashed] = result
-                # # something is wrong if we are here more than expected
-                # # empty and turn it off
-                if (
-                    max_cache_entries is not None and
-                    cached.missed > max_cache_entries
-                ):
-                    cached.off = True
-                    cached.cache.clear()
+
+                if max_cache_entries is None or len(cache) < max_cache_entries:
+                    cache[hashed] = result
 
             return result
 

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import cssutils
 import threading
+from premailer.cache import function_cache
 from operator import itemgetter
 try:
     from collections import OrderedDict
@@ -15,6 +17,7 @@ def format_value(prop):
         return prop.propertyValue.cssText.strip()
 
 
+@function_cache()
 def csstext_to_pairs(csstext):
     """
     csstext_to_pairs takes css text and make it to list of

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -184,10 +184,12 @@ class Premailer(object):
             cssutils.log.setLevel(cssutils_logging_level)
 
     def _parse_css_string(self, css_body, validate=True):
+        max_cache_entries = 0
         if self.cache_css_parsing:
-            return _cache_parse_css_string(css_body, validate=validate)
+            max_cache_entries = 1000
 
-        return cssutils.parseString(css_body, validate=validate)
+        return _cache_parse_css_string(css_body, validate=validate,
+                                       max_cache_entries=max_cache_entries)
 
     def _parse_style_rules(self, css_body, ruleset_index):
         """Returns a list of rules to apply to this doc and a list of rules

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -137,28 +137,46 @@ class Premailer(object):
                  disable_leftover_css=False,
                  align_floating_images=True,
                  remove_unset_properties=True):
+
+        '''
+        Initializes the premailer class.
+
+        TODO: document the rest of options
+
+        base_url: Specifies base URL for loading external stylesheets via
+            relative URLs.
+
+            If base_url is True, premailer will transform all URLs by
+            joining them with the base_url.
+
+        preserve_internal_links: If specified, the URL transforming behavior
+            enabled by setting base_url to True will be disabled for links to
+            named anchors.
+
+        preserve_inline_attachments: If specified, the URL transforming
+            behavior enabled by setting base_url to True will be disabled for
+            any links with cid: scheme.
+
+        disable_link_rewrites: If specified, the URL transforming behavior
+            enabled by setting base_url to True will be disabled altogether.
+
+        keep_style_tags: Specifies whether to delete the <style> tag once
+            it's been processed. If True, all original css will be
+            preserved.
+
+        include_star_selectors: Specifies whether to process or ignore
+            selectors like '* { foo:bar; }'
+        '''
+
         self.html = html
         self.base_url = base_url
-
-        # If base_url is specified, it is used for loading external stylesheets
-        # via relative URLs.
-        #
-        # Also, if base_url is specified, premailer will transform all URLs by
-        # joining them with the base_url. Setting preserve_internal_links to
-        # True will disable this behavior for links to named anchors. Setting
-        # preserve_inline_attachments to True will disable this behavior for
-        # any links with cid: scheme. Setting disable_link_rewrites to True
-        # will disable this behavior altogether.
         self.disable_link_rewrites = disable_link_rewrites
         self.preserve_internal_links = preserve_internal_links
         self.preserve_inline_attachments = preserve_inline_attachments
         self.exclude_pseudoclasses = exclude_pseudoclasses
-        # whether to delete the <style> tag once it's been processed
-        # this will always preserve the original css
         self.keep_style_tags = keep_style_tags
         self.remove_classes = remove_classes
         self.capitalize_float_margin = capitalize_float_margin
-        # whether to process or ignore selectors like '* { foo:bar; }'
         self.include_star_selectors = include_star_selectors
         if isinstance(external_styles, STR_TYPE):
             external_styles = [external_styles]

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -445,7 +445,9 @@ class Premailer(object):
             items = sel(page)
             if len(items):
                 # same so process it first
-                processed_style = csstext_to_pairs(style)
+                processed_style = csstext_to_pairs(
+                    style, max_cache_entries=self.cache_css_parsing_size
+                )
 
                 for item in items:
                     item_id = id(item)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -63,7 +63,7 @@ def get_or_create_head(root):
 
 
 @function_cache()
-def _cache_parse_css_string(css_body, validate=True):
+def _parse_css_string(css_body, validate=True):
     """
         This function will cache the result from cssutils
         It is a big gain when number of rules is big
@@ -211,11 +211,6 @@ class Premailer(object):
         if cssutils_logging_level:
             cssutils.log.setLevel(cssutils_logging_level)
 
-    def _parse_css_string(self, css_body, validate=True):
-        return _cache_parse_css_string(
-            css_body, validate=validate,
-            max_cache_entries=self.cache_css_parsing_size)
-
     def _parse_style_rules(self, css_body, ruleset_index):
         """Returns a list of rules to apply to this doc and a list of rules
         that won't be used because e.g. they are pseudoclasses. Rules
@@ -244,9 +239,10 @@ class Premailer(object):
         # empty string
         if not css_body:
             return rules, leftover
-        sheet = self._parse_css_string(
+        sheet = _parse_css_string(
             css_body,
-            validate=not self.disable_validation
+            validate=not self.disable_validation,
+            max_cache_entries=self.cache_css_parsing_size
         )
         for rule in sheet:
             # handle media rule

--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -34,6 +34,24 @@ class TestCache(unittest.TestCase):
 
         self.assertEqual(test['call_count'], 13)
 
+    def test_does_not_clear_cache_on_off(self):
+        test = {'call_count': 0}
+
+        def test_func(*args, **kwargs):
+            test['call_count'] += 1
+
+        cache_decorator = function_cache()
+        wrapper = cache_decorator(test_func)
+        wrapper(1, 1, t=1, max_cache_entries=2)
+        wrapper(1, 2, t=1, max_cache_entries=2)
+        # turn off
+        wrapper(1, 3, t=1, max_cache_entries=2)
+        # call 10 more times
+        for _ in range(10):
+            wrapper(1, 2, t=1, max_cache_entries=2)
+
+        self.assertEqual(test['call_count'], 3)
+
     def test_cache_hit(self):
         test = {'call_count': 0}
 

--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -9,7 +9,12 @@ class TestCache(unittest.TestCase):
 
     @raises(TypeError)
     def test_expected_max_entries_raise(self):
-        function_cache(expected_max_entries='testing')
+        def test_func():
+            pass
+
+        cache_decorator = function_cache()
+        wrapper = cache_decorator(test_func)
+        wrapper(max_cache_entries='testing')
 
     def test_auto_turn_off(self):
         test = {'call_count': 0}
@@ -17,15 +22,15 @@ class TestCache(unittest.TestCase):
         def test_func(*args, **kwargs):
             test['call_count'] += 1
 
-        cache_decorator = function_cache(expected_max_entries=2)
+        cache_decorator = function_cache()
         wrapper = cache_decorator(test_func)
-        wrapper(1, 1, t=1)
-        wrapper(1, 2, t=1)
+        wrapper(1, 1, t=1, max_cache_entries=2)
+        wrapper(1, 2, t=1, max_cache_entries=2)
         # turn off
-        wrapper(1, 3, t=1)
+        wrapper(1, 3, t=1, max_cache_entries=2)
         # call 10 more times
         for _ in range(10):
-            wrapper(1, 3, t=1)
+            wrapper(1, 3, t=1, max_cache_entries=2)
 
         self.assertEqual(test['call_count'], 13)
 
@@ -35,13 +40,12 @@ class TestCache(unittest.TestCase):
         def test_func(*args, **kwargs):
             test['call_count'] += 1
 
-        cache_decorator = function_cache(expected_max_entries=20)
+        cache_decorator = function_cache()
         wrapper = cache_decorator(test_func)
-        wrapper(1, 1, t=1)
-        wrapper(1, 2, t=1)
-        # turn off
-        wrapper(1, 3, t=1)
+        wrapper(1, 1, t=1, max_cache_entries=20)
+        wrapper(1, 2, t=1, max_cache_entries=20)
+        wrapper(1, 3, t=1, max_cache_entries=20)
         # call 10 more times
         for _ in range(10):
-            wrapper(1, 3, t=1)
+            wrapper(1, 3, t=1, max_cache_entries=20)
             self.assertEqual(test['call_count'], 3)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2493,7 +2493,7 @@ sheet" type="text/css">
         </html>"""
 
         p = Premailer(html, cache_css_parsing=False)
-        self.assertFalse(p.cache_css_parsing)
+        self.assertEqual(p.cache_css_parsing_size, 0)
         # run one time first
         p.transform()
         result_html = p.transform()

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2467,7 +2467,7 @@ sheet" type="text/css">
         result_html = p.transform()
         compare_html(expect_html, result_html)
 
-    def test_turnoff_cache_works_as_expected(self):
+    def test_turnoff_parsing_cache_works_as_expected(self):
         html = """<html>
         <head>
         <style>
@@ -2494,6 +2494,39 @@ sheet" type="text/css">
 
         p = Premailer(html, cache_css_parsing=False)
         self.assertEqual(p.cache_css_parsing_size, 0)
+        # run one time first
+        p.transform()
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_turnoff_output_cache_works_as_expected(self):
+        html = """<html>
+        <head>
+        <style>
+        .color {
+            color: green;
+        }
+        div.example {
+            font-size: 10px;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="color example"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="color example" style="color:green; font-size:10px"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, cache_css_output=False)
+        self.assertEqual(p.cache_css_output_size, 0)
         # run one time first
         p.transform()
         result_html = p.transform()


### PR DESCRIPTION
On [cppreference-doc](https://github.com/p12tic/cppreference-doc) we are processing around 4000 comparatively large pages using premailer. This takes a while with the current implementation. After looking into profiler results and doing some experimental changes it turns out that simply caching results of more functions and increasing the size of the caches speed up premailer by around 2.5 times.

This PR implements the above-mentioned changes in a way that the new behavior can be enabled on runtime explicitly, old-behavior is default and existing users are almost not impacted.

The `function_cache` decorator is modified to accept the size of the cache as a argument to the wrapper, so that it can be changed on runtime. The size of the caches may now be controlled via additional parameter to the `Premailer.__init__` method.

Also, `function_cache` is modified not to drop the contents of the cache when it overflows: this is the canonical behavior of caches. Small cache may still be very useful for handling the majority of requests and since it already reached the maximum size without inducing out of memory condition, being at the maximum size instead of zero will likely not induce out of memory condition later. If users are concerned about an out of memory condition arising later, when doing other tasks, we should provide a method to clear caches explicitly.

Furthermore, `function_cache` is modified to convert `list` arguments to `tuples` so that they can be hashed. `_HashedSeq` can be retired this way.

Caching behavior has been added to the top functions that I saw in the profiling results. The cache itself has very low overhead, so we know that at worst case we will only increase memory usage without reducing performance too much.

Finally, python 2.6 and 3.3 have been removed from the travis.yml as the upstream testing tools no longer support these python versions.

Please let me know what do you think about this. Thanks for your time!

