### PR TITLE
Accept kwargs for `transform()` function

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -651,8 +651,8 @@ class Premailer(object):
             head.append(style)
 
 
-def transform(html, base_url=None):
-    return Premailer(html, base_url=base_url).transform()
+def transform(html, **kwargs):
+    return Premailer(html, **kwargs).transform()
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -617,36 +617,6 @@ ple.com/bg.png); color:#123; font-family:Omerta">
 
         compare_html(expect_html, result_html)
 
-    def test_shortcut_function(self):
-        # you don't have to use this approach:
-        #   from premailer import Premailer
-        #   p = Premailer(html, base_url=base_url)
-        #   print p.transform()
-        # You can do it this way:
-        #   from premailer import transform
-        #   print transform(html, base_url=base_url)
-
-        html = '''<html>
-        <head>
-        <style type="text/css">h1{color:#123}</style>
-        </head>
-        <body>
-        <h1>Hi!</h1>
-        </body>
-        </html>'''
-
-        expect_html = '''<html>
-        <head></head>
-        <body>
-        <h1 style="color:#123">Hi!</h1>
-        </body>
-        </html>'''
-
-        p = Premailer(html)
-        result_html = p.transform()
-
-        compare_html(expect_html, result_html)
-
     def fragment_in_html(self, fragment, html, fullMessage=False):
         if fullMessage:
             message = '"{0}" not in\n{1}'.format(fragment, html)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -232,6 +232,43 @@ class Tests(unittest.TestCase):
         result_html = transform(html)
         compare_html(expect_html, result_html)
 
+    def test_kwargs_html_shortcut_function(self):
+        """test the transform function with kwargs passed"""
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        </head>
+        <body>
+        <h1 style="color:red">Hi!</h1>
+        <p><strong style="text-decoration:none">Yes!</strong></p>
+        </body>
+        </html>"""
+
+        result_html = transform(html, keep_style_tags=True)
+        compare_html(expect_html, result_html)
+
     def test_empty_style_tag(self):
         """empty style tag"""
 


### PR DESCRIPTION
This minor change just passes `**kwargs` through the `transform()` shortcut function to the Premailer constructor. This should make the shortcut a lot more versatile.