### PR TITLE
better http error caching when downloading

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -533,7 +533,9 @@ class Premailer(object):
             return out
 
     def _load_external_url(self, url):
-        return requests.get(url).text
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.text
 
     def _load_external(self, url):
         """loads an external stylesheet from a remote url or local path


### PR DESCRIPTION
It's "dangerous" to assume that every `requests.get(url)` works out perfectly. 
This PR makes that a bit more explicit and louder if it does fail to download a URL correctly. 

Sample traceback:
```
Traceback (most recent call last):
  File "dummy.py", line 31, in <module>
    print(premailer.transform(html, cssutils_logging_level=logging.ERROR))
  File "/Users/peterbe/dev/PYTHON/premailer/premailer/premailer.py", line 670, in transform
    return Premailer(**kwargs).transform(html, pretty_print=pretty_print)
  File "/Users/peterbe/dev/PYTHON/premailer/premailer/premailer.py", line 374, in transform
    css_body = self._load_external(href)
  File "/Users/peterbe/dev/PYTHON/premailer/premailer/premailer.py", line 551, in _load_external
    css_body = self._load_external_url(url)
  File "/Users/peterbe/dev/PYTHON/premailer/premailer/premailer.py", line 537, in _load_external_url
    response.raise_for_status()
  File "/Users/peterbe/virtualenvs/premailer/lib/python3.6/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://www.peterbe.com/static/css/base.min.79787297dbf5.csxxxxs
```