### PR TITLE
Add allow_insecure_ssl option for request.get() on external URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ never too late to start, so let's start here and now.
 dev
 -----
 
-* Add allow_insecure_ssl option for external URLs
+* Add ``allow_insecure_ssl`` option for external URLs
 
 3.5.0
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ premailer Changes
 Peter's note: Unfortunately, ``premailer`` has never kept a change log. But it's
 never too late to start, so let's start here and now.
 
+dev
+-----
+
+* Add allow_insecure_ssl option for external URLs
+
 3.5.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ The ``transform`` shortcut function transforms the given HTML using the defaults
     align_floating_images=True, # Add align attribute for floated images
     remove_unset_properties=True # Remove CSS properties if their value is unset when merged
     allow_network=True # allow network access to fetch linked css files
-    allow_insecure_ssl=False # don't allow unverified SSL certificates for exterenal links
+    allow_insecure_ssl=False # Don't allow unverified SSL certificates for external links
 
 For more advanced options, check out the code of the ``Premailer`` class
 and all its options in its constructor.

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ The ``transform`` shortcut function transforms the given HTML using the defaults
     align_floating_images=True, # Add align attribute for floated images
     remove_unset_properties=True # Remove CSS properties if their value is unset when merged
     allow_network=True # allow network access to fetch linked css files
+    allow_insecure_ssl=False # don't allow unverified SSL certificates for exterenal links
 
 For more advanced options, check out the code of the ``Premailer`` class
 and all its options in its constructor.
@@ -174,6 +175,7 @@ module.
                           Disable provided basic attributes (comma separated)
     --disable-validation  Disable CSSParser validation of attributes and values
     --pretty              Pretty-print the outputted HTML.
+    --allow-insecure-ssl  Skip SSL certificate verification for external URLs.
 
 A basic example:
 

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -149,6 +149,13 @@ def main(args):
         "--encoding", default="utf-8", help="Output encoding. The default is utf-8"
     )
 
+    parser.add_argument(
+        "--allow-insecure-ssl",
+        default=False,
+        action="store_true",
+        help="Skip SSL certificate verification for external URLs.",
+    )
+
     options = parser.parse_args(args)
 
     if options.disable_basic_attributes:
@@ -173,6 +180,7 @@ def main(args):
         base_path=options.base_path,
         disable_basic_attributes=options.disable_basic_attributes,
         disable_validation=options.disable_validation,
+        allow_insecure_ssl=options.allow_insecure_ssl,
     )
     options.outfile.write(
         p.transform(encoding=options.encoding, pretty_print=options.pretty)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -159,6 +159,7 @@ class Premailer(object):
         align_floating_images=True,
         remove_unset_properties=True,
         allow_network=True,
+        allow_insecure_ssl=False,
     ):
         self.html = html
         self.base_url = base_url
@@ -201,6 +202,7 @@ class Premailer(object):
         self.align_floating_images = align_floating_images
         self.remove_unset_properties = remove_unset_properties
         self.allow_network = allow_network
+        self.allow_insecure_ssl = allow_insecure_ssl
 
         if cssutils_logging_handler:
             cssutils.log.addHandler(cssutils_logging_handler)
@@ -539,7 +541,7 @@ class Premailer(object):
             return out
 
     def _load_external_url(self, url):
-        response = requests.get(url)
+        response = requests.get(url, verify=not self.allow_insecure_ssl)
         response.raise_for_status()
         return response.text
 

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2084,7 +2084,33 @@ ent:"" !important;display:block !important}
         p = premailer.premailer.Premailer("<p>A paragraph</p>")
         r = p._load_external_url(faux_uri)
 
-        mocked_requests.get.assert_called_once_with(faux_uri)
+        mocked_requests.get.assert_called_once_with(faux_uri, verify=True)
+        eq_(faux_response, r)
+
+    @mock.patch("premailer.premailer.requests")
+    def test_load_external_url_no_insecure_ssl(self, mocked_requests):
+        "Test premailer.premailer.Premailer._load_external_url"
+        faux_response = "This is not a response"
+        faux_uri = "https://example.com/site.css"
+        mocked_requests.get.return_value = MockResponse(faux_response)
+        p = premailer.premailer.Premailer(
+            "<p>A paragraph</p>", allow_insecure_ssl=False
+        )
+        r = p._load_external_url(faux_uri)
+
+        mocked_requests.get.assert_called_once_with(faux_uri, verify=True)
+        eq_(faux_response, r)
+
+    @mock.patch("premailer.premailer.requests")
+    def test_load_external_url_with_insecure_ssl(self, mocked_requests):
+        "Test premailer.premailer.Premailer._load_external_url"
+        faux_response = "This is not a response"
+        faux_uri = "https://example.com/site.css"
+        mocked_requests.get.return_value = MockResponse(faux_response)
+        p = premailer.premailer.Premailer("<p>A paragraph</p>", allow_insecure_ssl=True)
+        r = p._load_external_url(faux_uri)
+
+        mocked_requests.get.assert_called_once_with(faux_uri, verify=False)
         eq_(faux_response, r)
 
     @mock.patch("premailer.premailer.requests")


### PR DESCRIPTION
Added a new option and cmdline switch called 'allow_insecure_ssl' which, when enabled, will cause request.get() to be called with verify=False as additional parameter.