### PR TITLE
Updated lxml version for py34 environment in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,7 @@ deps =
     cssutils
     lxml==3.4.4
     coverage
+
+[testenv:py34] 
+deps = 
+    lxml<=4.3.5


### PR DESCRIPTION
Github travis CI was failing since lxml 4.4.0 no longer supported python 3.4.
Forced lxml version 4.3.5 in py34 test env in tox.ini