### PR TITLE
Pass validate to csstext_to_pairs

### DIFF
--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import, unicode_literals
 from .premailer import Premailer, transform  # noqa
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -20,7 +20,7 @@ def format_value(prop):
 
 
 @function_cache()
-def csstext_to_pairs(csstext):
+def csstext_to_pairs(csstext, validate=True):
     """
     csstext_to_pairs takes css text and make it to list of
     tuple of key,value.
@@ -31,7 +31,7 @@ def csstext_to_pairs(csstext):
         return sorted(
             [
                 (prop.name.strip(), format_value(prop))
-                for prop in cssutils.parseStyle(csstext)
+                for prop in cssutils.parseStyle(csstext, validate=validate)
             ],
             key=itemgetter(0),
         )

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -445,7 +445,7 @@ class Premailer(object):
             items = sel(page)
             if len(items):
                 # same so process it first
-                processed_style = csstext_to_pairs(style)
+                processed_style = csstext_to_pairs(style, validate=not self.disable_validation)
 
                 for item in items:
                     item_id = id(item)

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -445,7 +445,9 @@ class Premailer(object):
             items = sel(page)
             if len(items):
                 # same so process it first
-                processed_style = csstext_to_pairs(style, validate=not self.disable_validation)
+                processed_style = csstext_to_pairs(
+                    style, validate=not self.disable_validation
+                )
 
                 for item in items:
                     item_id = id(item)


### PR DESCRIPTION
Currently `disable_validation` does not work as it should since `csstext_to_pairs` does not receive the right `validate` parameter in order to disable validation.