### PR TITLE
Include tests in source distribution for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+recursive-include premailer/tests/*


### PR DESCRIPTION
OpenBSD relies on regression tests for porting, and it would be very helpful to have these tests bundled into the PyPI tarball.