### PR TITLE
Add preserve_handlebar_syntax option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ The ``transform`` shortcut function transforms the given HTML using the defaults
     disable_link_rewrites=False, # Allow link rewrites (e.g. using base_url)
     preserve_internal_links=False, # Do not preserve links to named anchors when using base_url
     preserve_inline_attachments=True, # Preserve links with cid: scheme when base_url is specified
+    preserve_handlebar_syntax=False # Preserve handlebar syntax from being encoded
     exclude_pseudoclasses=True, # Ignore pseudoclasses when processing styles
     keep_style_tags=False, # Discard original style tag
     include_star_selectors=False, # Ignore star selectors when processing styles

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -518,8 +518,16 @@ class Premailer(object):
                     lambda m: "/*<![CDATA[*/%s/*]]>*/" % m.group(1), out
                 )
             if self.preserve_handlebar_syntax:
-                while len(x := out.split('%7B%7B', 1)) > 1 and len(y := x[1].split('%7D%7D', 1)) > 1:
-                    out = x[0] + '{{' + unquote(y[0]) + '}}' + y[1]
+                while True:
+                    x = out.split("%7B%7B", 1)
+                    if len(x) > 1:
+                        y = x[1].split("%7D%7D", 1)
+                        if len(y) > 1:
+                            out = x[0] + "{{" + unquote(y[0]) + "}}" + y[1]
+                        else:
+                            break
+                    else:
+                        break
             return out
 
     def _load_external_url(self, url):

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -4,6 +4,7 @@ import os
 import re
 import warnings
 from collections import OrderedDict
+from html import escape, unescape
 from urllib.parse import urljoin, urlparse, unquote
 
 import cssutils
@@ -312,9 +313,7 @@ class Premailer(object):
             if self.preserve_handlebar_syntax:
                 stripped = re.sub(
                     r'="{{(.*?)}}"',
-                    lambda match: '="{{'
-                    + match.groups()[0].replace('"', "%22")
-                    + '}}"',
+                    lambda match: '="{{' + escape(match.groups()[0]) + '}}"',
                     stripped,
                 )
 
@@ -530,7 +529,7 @@ class Premailer(object):
             if self.preserve_handlebar_syntax:
                 out = re.sub(
                     r'="%7B%7B(.+?)%7D%7D"',
-                    lambda match: '="{{' + unquote(match.groups()[0]) + '}}"',
+                    lambda match: '="{{' + unescape(unquote(match.groups()[0])) + '}}"',
                     out,
                 )
             return out

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -312,8 +312,10 @@ class Premailer(object):
             if self.preserve_handlebar_syntax:
                 stripped = re.sub(
                     r'="{{(.*?)}}"',
-                    lambda match: '="{{' + match.groups()[0].replace('"', '%22') + '}}"',
-                    stripped
+                    lambda match: '="{{'
+                    + match.groups()[0].replace('"', "%22")
+                    + '}}"',
+                    stripped,
                 )
 
             tree = etree.fromstring(stripped, parser).getroottree()
@@ -529,7 +531,7 @@ class Premailer(object):
                 out = re.sub(
                     r'="%7B%7B(.+?)%7D%7D"',
                     lambda match: '="{{' + unquote(match.groups()[0]) + '}}"',
-                    out
+                    out,
                 )
             return out
 

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2985,3 +2985,57 @@ sheet" type="text/css">
         p = Premailer(html, exclude_pseudoclasses=False, keep_style_tags=True)
         result_html = p.transform()
         compare_html(expect_html, result_html)
+
+    def test_preserve_handlebar_syntax_false(self):
+        """Demonstrate encoding of handlebar syntax with preservation disabled.
+
+        Original issue: https://github.com/peterbe/premailer/issues/248
+        """
+
+        html = """
+            <html>
+            <img src="{{ img_src }}">
+            <a href="{{ url }}"></a>
+            </html>
+        """
+
+        expect_html = """
+<html>
+    <head>
+    </head>
+    <body>
+    <img src="%7B%7B%20img_src%20%7D%7D">
+    <a href="%7B%7B%20url%20%7D%7D"></a>
+    </body>
+</html>
+        """
+        p = Premailer(html)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_preserve_handlebar_syntax_true(self):
+        """Demonstrate encoding of handlebar syntax with preservation enabled.
+
+        Original issue: https://github.com/peterbe/premailer/issues/248
+        """
+
+        html = """
+            <html>
+            <img src="{{ img_src }}">
+            <a href="{{ url }}"></a>
+            </html>
+        """
+
+        expect_html = """
+<html>
+    <head>
+    </head>
+    <body>
+    <img src="{{ img_src }}">
+    <a href="{{ url }}"></a>
+    </body>
+</html>
+        """
+        p = Premailer(html, preserve_handlebar_syntax=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2993,8 +2993,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ data | default: 'Test.' }}">
-            <a href="{{ data | default: "Test." }}"></a>
+            <img src="{{ data | default: 'Test & <code>' }}">
+            <a href="{{ data | default: "Test & <code>" }}"></a>
             </html>
         """
 
@@ -3003,8 +3003,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="%7B%7B%20data%20%7C%20default:%20'Test.'%20%7D%7D">
-    <a href="%7B%7B%20data%20%7C%20default:%20" test.></a>
+    <img src="%7B%7B%20data%20%7C%20default:%20'Test%20&amp;%20&lt;code&gt;'%20%7D%7D">
+    <a href="%7B%7B%20data%20%7C%20default:%20" test>" }}"&gt;</a>
     </body>
 </html>
         """
@@ -3020,8 +3020,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ data | default: 'Test.' }}">
-            <a href="{{ data | default: "Test." }}"></a>
+            <img src="{{ data | default: 'Test & <code>' }}">
+            <a href="{{ data | default: "Test & <code>" }}"></a>
             </html>
         """
 
@@ -3030,8 +3030,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="{{ data | default: 'Test.' }}">
-    <a href="{{ data | default: "Test." }}"></a>
+    <img src="{{ data | default: 'Test & <code>' }}">
+    <a href="{{ data | default: "Test & <code>" }}"></a>
     </body>
 </html>
         """

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2993,8 +2993,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ data | default: 'This is a string literal.' }}">
-            <a href="{{ data | default: "This is a string literal." }}"></a>
+            <img src="{{ data | default: 'Test.' }}">
+            <a href="{{ data | default: "Test." }}"></a>
             </html>
         """
 
@@ -3003,8 +3003,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="%7B%7B%20data%20%7C%20default:%20'This%20is%20a%20string%20literal.'%20%7D%7D">
-    <a href="%7B%7B%20data%20%7C%20default:%20" this is a string literal.></a>
+    <img src="%7B%7B%20data%20%7C%20default:%20'Test.'%20%7D%7D">
+    <a href="%7B%7B%20data%20%7C%20default:%20" test.></a>
     </body>
 </html>
         """
@@ -3020,8 +3020,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ data | default: 'This is a string literal.' }}">
-            <a href="{{ data | default: "This is a string literal." }}"></a>
+            <img src="{{ data | default: 'Test.' }}">
+            <a href="{{ data | default: "Test." }}"></a>
             </html>
         """
 
@@ -3030,8 +3030,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="{{ data | default: 'This is a string literal.' }}">
-    <a href="{{ data | default: "This is a string literal." }}"></a>
+    <img src="{{ data | default: 'Test.' }}">
+    <a href="{{ data | default: "Test." }}"></a>
     </body>
 </html>
         """

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2993,8 +2993,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ img_src }}">
-            <a href="{{ url }}"></a>
+            <img src="{{ data | default: 'This is a string literal.' }}">
+            <a href="{{ data | default: "This is a string literal." }}"></a>
             </html>
         """
 
@@ -3003,8 +3003,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="%7B%7B%20img_src%20%7D%7D">
-    <a href="%7B%7B%20url%20%7D%7D"></a>
+    <img src="%7B%7B%20data%20%7C%20default:%20'This%20is%20a%20string%20literal.'%20%7D%7D">
+    <a href="%7B%7B%20data%20%7C%20default:%20" this is a string literal.></a>
     </body>
 </html>
         """
@@ -3020,8 +3020,8 @@ sheet" type="text/css">
 
         html = """
             <html>
-            <img src="{{ img_src }}">
-            <a href="{{ url }}"></a>
+            <img src="{{ data | default: 'This is a string literal.' }}">
+            <a href="{{ data | default: "This is a string literal." }}"></a>
             </html>
         """
 
@@ -3030,8 +3030,8 @@ sheet" type="text/css">
     <head>
     </head>
     <body>
-    <img src="{{ img_src }}">
-    <a href="{{ url }}"></a>
+    <img src="{{ data | default: 'This is a string literal.' }}">
+    <a href="{{ data | default: "This is a string literal." }}"></a>
     </body>
 </html>
         """

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -2985,8 +2985,8 @@ sheet" type="text/css">
         result_html = p.transform()
         compare_html(expect_html, result_html)
 
-    def test_preserve_handlebar_syntax_false(self):
-        """Demonstrate encoding of handlebar syntax with preservation disabled.
+    def test_preserve_handlebar_syntax(self):
+        """Demonstrate encoding of handlebar syntax with preservation.
 
         Original issue: https://github.com/peterbe/premailer/issues/248
         """
@@ -2998,34 +2998,7 @@ sheet" type="text/css">
             </html>
         """
 
-        expect_html = """
-<html>
-    <head>
-    </head>
-    <body>
-    <img src="%7B%7B%20data%20%7C%20default:%20'Test%20&amp;%20&lt;code&gt;'%20%7D%7D">
-    <a href="%7B%7B%20data%20%7C%20default:%20" test>" }}"&gt;</a>
-    </body>
-</html>
-        """
-        p = Premailer(html)
-        result_html = p.transform()
-        compare_html(expect_html, result_html)
-
-    def test_preserve_handlebar_syntax_true(self):
-        """Demonstrate encoding of handlebar syntax with preservation enabled.
-
-        Original issue: https://github.com/peterbe/premailer/issues/248
-        """
-
-        html = """
-            <html>
-            <img src="{{ data | default: 'Test & <code>' }}">
-            <a href="{{ data | default: "Test & <code>" }}"></a>
-            </html>
-        """
-
-        expect_html = """
+        expected_preserved_html = """
 <html>
     <head>
     </head>
@@ -3034,7 +3007,22 @@ sheet" type="text/css">
     <a href="{{ data | default: "Test & <code>" }}"></a>
     </body>
 </html>
-        """
+"""
+
+        expected_neglected_html = """
+<html>
+    <head>
+    </head>
+    <body>
+    <img src="%7B%7B%20data%20%7C%20default:%20'Test%20&amp;%20&lt;code&gt;'%20%7D%7D">
+    <a href="%7B%7B%20data%20%7C%20default:%20" test>" }}"&gt;</a>
+    </body>
+</html>
+"""
         p = Premailer(html, preserve_handlebar_syntax=True)
-        result_html = p.transform()
-        compare_html(expect_html, result_html)
+        result_preserved_html = p.transform()
+        compare_html(expected_preserved_html, result_preserved_html)
+
+        p = Premailer(html)
+        result_neglected_html = p.transform()
+        compare_html(expected_neglected_html, result_neglected_html)


### PR DESCRIPTION
Resolves #248 

### Description
#### Added
- `preserve_handlebar_syntax` option (Defaults to `False`)
   - Replaces any `"` between `="{{` and `}}"` in the `html` string (prior to being encoded) with `%22`.
      - This is to ensure that double-quotes within the handlebar syntax don't break when encoded.
      - This works because, as the below statement explains, everything with the `{{}}` (including `%22`) will be decoded after the rest of the string has been encoded.
   - Use `unquote()` to decode everything between every pair of `="%7B%7B` and `%7D%7D"` (the encoded versions of `{{` and `}}`).
   
### Motivations
- Like the author of #248, I too ran into an issue when attempting to transform a template with handlebar syntax in HTML attributes.
   - In my case, I was using the [Django templating language](https://docs.djangoproject.com/en/3.1/ref/templates/language/).

### Additional Context
- I just used the name `preserve_handlebar_syntax` because that's what @peterbe wrote in #248.

I really enjoy working with this library and would appreciate any feedback because I am using this library in other projects.