### PR TITLE
Fix inlined styles ordering - no longer sorts rules alphabetically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,27 @@ never too late to start, so let's start here and now.
 Unreleased
 ----------
 * New option ``session=None`` to provide the session used for making http requests.
+* Bug fix: inlined styles are no longer sorted alphabetically. This preserves the input
+rule order so that premailer does not break style precedence where order is significant, e.g.
+
+```
+div {
+  /* Padding on all sides is 10px. */
+  padding-left: 5px;
+  padding: 10px;
+}
+```
+
+```
+div {
+  /* Padding on the left side is 5px, on other sides is 10px. */
+  padding: 10px;
+  padding-left: 5px;
+}
+```
+
+Prior to this fix premailer would swap the rules in the first example to look like the second.
+
 
 3.9.0
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,25 +8,23 @@ Unreleased
 ----------
 * New option ``session=None`` to provide the session used for making http requests.
 * Bug fix: inlined styles are no longer sorted alphabetically. This preserves the input
-rule order so that premailer does not break style precedence where order is significant, e.g.
+  rule order so that premailer does not break style precedence where order is significant, e.g.
 
-```
-div {
-  /* Padding on all sides is 10px. */
-  padding-left: 5px;
-  padding: 10px;
-}
-```
+  .. code-block:: css
 
-```
-div {
-  /* Padding on the left side is 5px, on other sides is 10px. */
-  padding: 10px;
-  padding-left: 5px;
-}
-```
+    div {
+      /* Padding on all sides is 10px. */
+      padding-left: 5px;
+      padding: 10px;
+    }
 
-Prior to this fix premailer would swap the rules in the first example to look like the second.
+    div {
+      /* Padding on the left side is 5px, on other sides is 10px. */
+      padding: 10px;
+      padding-left: 5px;
+    }
+
+  Prior to this fix premailer would swap the rules in the first example to look like the second.
 
 
 3.9.0

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -1,6 +1,5 @@
 import cssutils
 import threading
-from operator import itemgetter
 from collections import OrderedDict
 
 from premailer.cache import function_cache
@@ -22,13 +21,10 @@ def csstext_to_pairs(csstext, validate=True):
     # The lock is required to avoid ``cssutils`` concurrency
     # issues documented in issue #65
     with csstext_to_pairs._lock:
-        return sorted(
-            [
-                (prop.name.strip(), format_value(prop))
-                for prop in cssutils.parseStyle(csstext, validate=validate)
-            ],
-            key=itemgetter(0),
-        )
+        return [
+            (prop.name.strip(), format_value(prop))
+            for prop in cssutils.parseStyle(csstext, validate=validate)
+        ]
 
 
 csstext_to_pairs._lock = threading.RLock()

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -710,8 +710,8 @@ class Tests(unittest.TestCase):
         <head>
         <title>Title</title>
         </head>
-        <body style="background:url(http://exam
-ple.com/bg.png); color:#123; font-family:Omerta">
+        <body style="color:#123; background:url(http://exam
+ple.com/bg.png); font-family:Omerta">
         <h1>Hi!</h1>
         </body>
         </html>""".replace(
@@ -933,7 +933,7 @@ ical-align:middle" bgcolor="red" valign="middle">Cell 2</td>
         </head>
         <body>
         <p style="text-align:center">Text</p>
-        <table style="height:300px; width:200px">
+        <table style="width:200px; height:300px">
           <tr>
             <td style="background-color:red" bgcolor="red">Cell 1</td>
             <td style="background-color:red" bgcolor="red">Cell 2</td>
@@ -1052,7 +1052,7 @@ b
 </head>
 <body>
 <h1 style="Margin:0">a</h1>
-<h2 style="Margin-bottom:0; Margin-left:0; Margin-right:0; Margin-top:0">
+<h2 style="Margin-top:0; Margin-bottom:0; Margin-left:0; Margin-right:0">
 b
 </h2>
 </body>
@@ -1252,6 +1252,39 @@ b
         </head>
         <body>
         <div style="text-align:right" align="right">First div</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_css_ordering_preserved(self):
+        """For cases like these padding rules, it's important that the style that
+        should be applied comes last so that premailer follows the same rules that
+        browsers use to determine precedence."""
+
+        html = """<html>
+        <head>
+        <style type="text/css">
+        div {
+            padding-left: 6px;
+            padding-right: 6px;
+            padding: 4px;
+        }
+        </style>
+        </head>
+        <body>
+        <div>Some text</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="padding-left:6px; padding-right:6px; padding:4px">Some text</div>
         </body>
         </html>"""
 


### PR DESCRIPTION
Fixes #260.

The original commit that [added sorting here](https://github.com/peterbe/premailer/commit/725c9cfedfa934187e9e2139c865ccbd16e649f4) did so to maintain a stable order for testing. The OrderedDict (which is also the default behavior in modern Python) should ensure this without the sort being necessary.

This should be a patch release.