### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -40,9 +40,9 @@ class TestFunctionCache(unittest.TestCase):
             "cache.py", os.path.join("premailer", "cache.py")
         )
 
-        self.assertEquals(type(cache_module.cache), cachetools.TTLCache)
-        self.assertEquals(cache_module.cache.maxsize, 50)
-        self.assertEquals(cache_module.cache.ttl, 10)
+        self.assertEqual(type(cache_module.cache), cachetools.TTLCache)
+        self.assertEqual(cache_module.cache.maxsize, 50)
+        self.assertEqual(cache_module.cache.ttl, 10)
 
     def test_cache_multithread_synchronization(self):
         """


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .