### PR TITLE
Fix `merge_styles` for proper ordering of styles w.r.t. "constituent" styles

### DIFF
--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -61,10 +61,13 @@ def merge_styles(inline_style, new_styles, classes, remove_unset_properties=Fals
 
     # keep always the old inline style
     if inline_style:
+        normal_styles_dict = styles[""]
         # inline should be a declaration list as I understand
         # ie property-name:property-value;...
         for k, v in csstext_to_pairs(inline_style):
-            styles[""][k] = v
+            if k in normal_styles_dict:
+                del normal_styles_dict[k]
+            normal_styles_dict[k] = v
 
     normal_styles = []
     pseudo_styles = []

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -24,5 +24,5 @@ class TestMergeStyle(unittest.TestCase):
         csstext = merge_styles(inline_style, new_styles, classes)
         self.assertEqual(
             # ideally premailer could eliminate margin-bottom altogether
-            [("margin-bottom", "5px"), ("margin", "0")], csstext_to_pairs(csstext)
+            [("margin-bottom", "10px"), ("margin", "0")], csstext_to_pairs(csstext)
         )

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -15,3 +15,14 @@ class TestMergeStyle(unittest.TestCase):
         # Invalid syntax does not raise
         inline = "{color:pink} :hover{color:purple} :active{color:red}"
         merge_styles(inline, [], [])
+
+    def test_constituent_styles(self):
+        # "constituent": `margin-bottom` is a constituent style of `margin`
+        new_styles = [[("margin", "5px"), ("margin-bottom", "10px")]]
+        classes = [""]
+        inline_style = "margin: 0"
+        csstext = merge_styles(inline_style, new_styles, classes)
+        self.assertEqual(
+            # ideally premailer could eliminate margin-bottom altogether
+            [("margin-bottom", "5px"), ("margin", "0")], csstext_to_pairs(csstext)
+        )

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -24,5 +24,6 @@ class TestMergeStyle(unittest.TestCase):
         csstext = merge_styles(inline_style, new_styles, classes)
         self.assertEqual(
             # ideally premailer could eliminate margin-bottom altogether
-            [("margin-bottom", "10px"), ("margin", "0")], csstext_to_pairs(csstext)
+            [("margin-bottom", "10px"), ("margin", "0")],
+            csstext_to_pairs(csstext),
         )


### PR DESCRIPTION
"Constituent" styles are, for example, `margin-bottom` for `margin`.

# Rationale

To illustrate the problem, suppose you have this HTML:

```html
<style>
	.c {
		display: inline-block;
		width: 50px;
		height: 50px;
		border: 5px solid red;
		border-bottom-width: 10px;
	}
</style>
<div class="c" style="border: 1px solid blue;"></div>
<!-- Effective style: border: 1px solid blue; -->
```

![input](https://user-images.githubusercontent.com/52021/139588410-7c26551e-f77f-4efb-b3a7-cc57d4a55413.png)

After "premailing" with the current version, this becomes

```html
<html>
  <head></head>
  <body>
    <div class="c" style="display:inline-block; width:50px; height:50px; border:1px solid blue; border-bottom-width:10px" width="50" height="50"></div>
    <!-- Effective style: border: 1px solid blue; border-bottom-width: 10px; -->
  </body>
</html>
```
![actual_output](https://user-images.githubusercontent.com/52021/139588452-1fc45cc5-40d0-4eac-a9bc-f4dc169fa937.png)

what is obviously wrong. The desired output would be:

```
<html>
  <head></head>
  <body>
    <div class="c" style="display:inline-block; width:50px; height:50px; border-bottom-width:10px; border:1px solid blue" width="50" height="50"></div>
    <!-- Effective style: border: 1px solid blue; -->
  </body>
</html>
```

Note the ordering of  `border` and `border-bottom-width`.

# Suggested fix

The underlying reason for this error is that when you assign to an existing key in `OrderedDict`, it replaces the value in-place instead of appending it to the end. That is,

```
>>> import collections
>>> d = collections.OrderedDict((("a", 1), ("b", 2)))
>>> d["a"] = 3
>>> d
OrderedDict([('a', 3), ('b', 2)])
```

This way, the inline `border` style in the example takes place of the `border` style inherited from the `.c` class, and gets lesser priority than `border-bottom-width`.

The simplest fix to achieve the desired behavior would be to `del` the key from the `OrderedDict` first.

# PR contents

PR contains a fix and a unit test failing without the fix.
