### PR TITLE
Improved preserve_handlebar_syntax regex

### DIFF
--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -345,8 +345,11 @@ class Premailer(object):
             # <a href="{{ "<Test>" }}"></a>
             if self.preserve_handlebar_syntax:
                 stripped = re.sub(
-                    r'="{{(.*?)}}"',
-                    lambda match: '="{{' + escape(match.groups()[0]) + '}}"',
+                    r'="([^"]*){{(.*?)}}([^"]*?)"',
+                    lambda match: '="' +
+                                  match.groups()[0] +
+                                  '{{' + escape(match.groups()[1]) + '}}' +
+                                  match.groups()[2] + '"',
                     stripped,
                 )
 
@@ -563,8 +566,11 @@ class Premailer(object):
             # attributes, with their single-character equivalents.
             if self.preserve_handlebar_syntax:
                 out = re.sub(
-                    r'="%7B%7B(.+?)%7D%7D"',
-                    lambda match: '="{{' + unescape(unquote(match.groups()[0])) + '}}"',
+                    r'="([^"]*)%7B%7B(.+?)%7D%7D([^"]*?)"',
+                    lambda match: '="' +
+                                  match.groups()[0] +
+                                  '{{' + unescape(unquote(match.groups()[1])) + '}}' +
+                                  match.groups()[2] + '"',
                     out,
                 )
             return out

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -3049,6 +3049,7 @@ sheet" type="text/css">
             <html>
             <img src="{{ data | default: 'Test & <code>' }}">
             <a href="{{ data | default: "Test & <code>" }}"></a>
+            <a href="mailto:{{ data | default: "Test & <code>" }}?subject=x"></a>
             </html>
         """
 
@@ -3059,6 +3060,7 @@ sheet" type="text/css">
     <body>
     <img src="{{ data | default: 'Test & <code>' }}">
     <a href="{{ data | default: "Test & <code>" }}"></a>
+    <a href="mailto:{{ data | default: "Test & <code>" }}?subject=x"></a>
     </body>
 </html>
 """
@@ -3070,6 +3072,7 @@ sheet" type="text/css">
     <body>
     <img src="%7B%7B%20data%20%7C%20default:%20'Test%20&amp;%20&lt;code&gt;'%20%7D%7D">
     <a href="%7B%7B%20data%20%7C%20default:%20" test>" }}"&gt;</a>
+    <a href="mailto:%7B%7B%20data%20%7C%20default:%20" test>" }}?subject=x"&gt;</a>
     </body>
 </html>
 """


### PR DESCRIPTION
Problem: 
preserve_handlebar_syntax=True doesn't preserve handlebars with characters before or after the handlebars.

Examples of html that don't preserve handlebars:
a href="mailto:{{ Test }}"
a href="{{ Test }}?subject=x"


Current regex code:
```
stripped = re.sub(
                    r'="{{(.*?)}}"',
                    lambda match: '="{{' + escape(match.groups()[0]) + '}}"',
                    stripped,
                )
```
```
out = re.sub(
                    r'="%7B%7B(.+?)%7D%7D"',
                    lambda match: '="{{' + unescape(unquote(match.groups()[0])) + '}}"',
                    out,
                )
```

Proposed regex code:
```
stripped = re.sub(
                    r'="([^"]*){{(.*?)}}([^"]*?)"',
                    lambda match: '="' +
                                  match.groups()[0] +
                                  '{{' + escape(match.groups()[1]) + '}}' +
                                  match.groups()[2] + '"',
                    stripped,
                )
```
https://regex101.com/r/tLC41B/2
```
out = re.sub(
                    r'="([^"]*)%7B%7B(.+?)%7D%7D([^"]*?)"',
                    lambda match: '="' +
                                  match.groups()[0] +
                                  '{{' + unescape(unquote(match.groups()[1])) + '}}' +
                                  match.groups()[2] + '"',
                    out,
                )
```
https://regex101.com/r/ADvQjO/1

Issue also here:
https://github.com/peterbe/premailer/issues/271

I also added a testcase to test_premailer.py for:
a href="mailto:{{ data | default: "Test & code" }}?subject=x"

I'm new to this, so I hope this is how it works.